### PR TITLE
Added CREATE EVENT feature using "POST MAPPING"

### DIFF
--- a/src/main/java/com/eventra/controller/EventController.java
+++ b/src/main/java/com/eventra/controller/EventController.java
@@ -1,41 +1,42 @@
 package com.eventra.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestBody;   // ✅ correct import
+
+import com.eventra.dto.EventDTO;
+import com.eventra.entity.Event;
+import com.eventra.service.EventService;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/events")
-@RequiredArgsConstructor
 public class EventController {
 
+    @Autowired 
+    private EventService eventService;
+
     @GetMapping
-    public ResponseEntity<List<EventInfo>> getAllEvents() {
-        // For now, return sample data since we don't have Event entity yet
-        List<EventInfo> events = List.of(
-            new EventInfo(1L, "Public Event 1", "2025-09-01", "This is a sample public event"),
-            new EventInfo(2L, "Public Event 2", "2025-09-05", "Another sample public event"),
-            new EventInfo(3L, "Public Event 3", "2025-09-10", "A third sample public event")
-        );
+    public ResponseEntity<List<Event>> getAllEvents() {
+        List<Event> events = eventService.getAllEvents();
         return ResponseEntity.ok(events);
     }
 
-    // Inner class for event info
-    public static class EventInfo {
-        public Long id;
-        public String title;
-        public String date;
-        public String description;
-
-        public EventInfo(Long id, String title, String date, String description) {
-            this.id = id;
-            this.title = title;
-            this.date = date;
-            this.description = description;
-        }
+    @PostMapping
+    public ResponseEntity<Event> createEvent(@RequestBody EventDTO eventDto) {
+ try {
+        System.out.println("eventService = " + eventService);
+        Event savedEvent = eventService.createEvent(eventDto);
+        return ResponseEntity.ok(savedEvent);
+    } catch (Exception e) {
+        e.printStackTrace(); // <--- this will show the real exception
+        throw e; // rethrow so test still fails
+    }
     }
 }

--- a/src/main/java/com/eventra/dto/EventDTO.java
+++ b/src/main/java/com/eventra/dto/EventDTO.java
@@ -1,0 +1,63 @@
+package com.eventra.dto;
+
+import java.time.LocalDate;
+
+public class EventDTO {
+    private LocalDate date;
+    private String description;
+    private String title;
+    private String status;
+    private String category;
+    private int capacity;
+    private String organizer;
+    private String location;
+
+    public LocalDate getDate(){
+        return date;
+    }
+    public String getDescription(){
+        return description;
+    }
+    public String getTitle(){
+        return title;
+    }
+    public String getStatus(){
+        return status;
+    }
+    public String getOrganizer(){
+        return organizer;
+    }
+    public String getLocation(){
+        return location;
+    }
+    public String getCategory(){
+        return category;
+    }
+    public int getCapacity(){
+        return capacity;
+    }
+    public void setCapacity(int capacity){
+        this.capacity=capacity;
+    }
+    public void setLocation(String loc){
+        this.location=loc;
+    }
+    public void setOrganizer(String org){
+        this.organizer=org;
+    }
+    public void setDate(LocalDate date){
+        this.date=date;
+    }
+    public void setDescription(String description){
+        this.description=description;
+    }
+    public void setTitle(String title){
+        this.title=title;
+    }
+    public void setStatus(String status){
+        this.status=status;
+    }
+    public void setCategory(String category){
+        this.category=category;
+    }
+}

--- a/src/main/java/com/eventra/entity/Event.java
+++ b/src/main/java/com/eventra/entity/Event.java
@@ -1,0 +1,82 @@
+package com.eventra.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name="events")
+public class Event {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String description;
+    private String location;
+    private String organizer;
+    private String status;
+    private LocalDate date;
+    private String category;
+    private Integer capacity;
+
+
+
+        public Event() {} // no-args constructor
+     public LocalDate getDate(){
+        return date;
+    }
+    public String getLocation(){
+        return location;
+    }
+    public String getOrganizer(){
+        return organizer;
+    }
+    public int getCapacity(){
+        return capacity;
+    }
+    public String getDescription(){
+        return description;
+    }
+    public String getTitle(){
+        return title;
+    }
+    public String getStatus(){
+        return status;
+    }
+    public String getCategory(){
+        return category;
+    }
+    public void setLocation(String location){
+        this.location=location;
+
+    }
+    public void setCapacity(int cap){
+        this.capacity=cap;
+    }
+    public void setOrganizer(String org){
+        this.organizer=org;
+    }
+    public void setDate(LocalDate date){
+        this.date=date;
+    }
+    public void setDescription(String description){
+        this.description=description;
+    }
+    public void setTitle(String title){
+        this.title=title;
+    }
+    public void setStatus(String status){
+        this.status=status;
+    }
+    public void setCategory(String category){
+        this.category=category;
+    }
+
+    
+}

--- a/src/main/java/com/eventra/repository/EventsRepository.java
+++ b/src/main/java/com/eventra/repository/EventsRepository.java
@@ -1,0 +1,10 @@
+
+package com.eventra.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.eventra.entity.Event;
+
+public interface EventsRepository extends JpaRepository<Event,Long>{
+    
+}

--- a/src/main/java/com/eventra/service/EventService.java
+++ b/src/main/java/com/eventra/service/EventService.java
@@ -1,0 +1,45 @@
+package com.eventra.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.eventra.dto.EventDTO;
+import com.eventra.entity.Event;
+import com.eventra.repository.EventsRepository;
+
+@Service
+public class EventService {
+@Autowired
+private EventsRepository rep;
+
+    //get all events
+    public List<Event> getAllEvents() {
+        return rep.findAll();
+    }
+
+    //create an event
+    public Event createEvent(EventDTO eventDto){
+        Event event=new Event();
+         event.setTitle(eventDto.getTitle());
+        event.setDescription(eventDto.getDescription());
+        event.setLocation(eventDto.getLocation());
+        event.setOrganizer(eventDto.getOrganizer());
+        
+        event.setCategory(eventDto.getCategory());
+        event.setDate(eventDto.getDate());
+event.setStatus(eventDto.getStatus());
+
+        // Default handling
+        if (eventDto.getCapacity() == 0) {
+            event.setCapacity(100); // default
+        } else {
+            event.setCapacity(eventDto.getCapacity());
+        }
+
+        return rep.save(event);
+
+    }
+    
+}

--- a/src/test/java/com/eventra/controller/EventController.java
+++ b/src/test/java/com/eventra/controller/EventController.java
@@ -1,0 +1,65 @@
+package com.eventra.controller;
+
+import com.eventra.dto.EventDTO;
+import com.eventra.entity.Event;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import com.eventra.repository.EventsRepository;
+import com.eventra.service.EventService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EventService eventService; // mocking the service
+
+    @Test
+    void testCreateEvent() throws Exception {
+        String eventJson = """
+            {
+              "date": "2025-10-05",
+              "description": "A tech conference on AI",
+              "title": "AI Summit 2025",
+              "status": "Scheduled",
+              "category": "Technology",
+              "capacity": 200,
+              "organizer": "Eventra Team",
+              "location": "Bangalore"
+            }
+        """;
+
+        Event mockEvent = new Event();
+        mockEvent.setTitle("AI Summit 2025");
+        mockEvent.setLocation("Bangalore");
+        mockEvent.setCapacity(200);
+
+        when(eventService.createEvent(any(EventDTO.class))).thenReturn(mockEvent);
+
+        mockMvc.perform(post("/api/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(eventJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("AI Summit 2025"))
+                .andExpect(jsonPath("$.location").value("Bangalore"))
+                .andExpect(jsonPath("$.capacity").value(200));
+    }
+}


### PR DESCRIPTION
Purpose:
It allows users (or an admin) to add a new event to the system.

- Endpoint: POST /api/events
- Input: JSON body with event details (title, description, date, location, organizer, status, category, capacity).
- Controller: Receives request → maps JSON to EventDTO.
- Service: Converts EventDTO → Event, sets defaults, saves to database.
- Repository: Persists Event in DB.
- Response: Returns saved Event as JSON with HTTP 200 OK.
- Testing: Testing via MockMvc ensures the endpoint works as expected.