### PR TITLE
Implement rate limiting for public endpoints

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/RateLimitProperties.java
@@ -1,0 +1,86 @@
+package com.sandeep.eventrabackend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@ConfigurationProperties(prefix = "app.rate-limit")
+public class RateLimitProperties {
+
+    private boolean enabled = true;
+    private EndpointLimit login = new EndpointLimit(5, Duration.ofMinutes(1));
+    private EndpointLimit signup = new EndpointLimit(3, Duration.ofMinutes(10));
+    private EndpointLimit forgotPassword = new EndpointLimit(3, Duration.ofMinutes(15));
+    private EndpointLimit contact = new EndpointLimit(5, Duration.ofMinutes(10));
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public EndpointLimit getLogin() {
+        return login;
+    }
+
+    public void setLogin(EndpointLimit login) {
+        this.login = login;
+    }
+
+    public EndpointLimit getSignup() {
+        return signup;
+    }
+
+    public void setSignup(EndpointLimit signup) {
+        this.signup = signup;
+    }
+
+    public EndpointLimit getForgotPassword() {
+        return forgotPassword;
+    }
+
+    public void setForgotPassword(EndpointLimit forgotPassword) {
+        this.forgotPassword = forgotPassword;
+    }
+
+    public EndpointLimit getContact() {
+        return contact;
+    }
+
+    public void setContact(EndpointLimit contact) {
+        this.contact = contact;
+    }
+
+    public static class EndpointLimit {
+        private int capacity;
+        private Duration window;
+
+        public EndpointLimit() {
+        }
+
+        public EndpointLimit(int capacity, Duration window) {
+            this.capacity = capacity;
+            this.window = window;
+        }
+
+        public int getCapacity() {
+            return capacity;
+        }
+
+        public void setCapacity(int capacity) {
+            this.capacity = capacity;
+        }
+
+        public Duration getWindow() {
+            return window;
+        }
+
+        public void setWindow(Duration window) {
+            this.window = window;
+        }
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.sandeep.eventrabackend.config;
 
 import com.sandeep.eventrabackend.security.JwtAuthenticationFilter;
+import com.sandeep.eventrabackend.security.RateLimitingFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -23,11 +25,14 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final RateLimitingFilter rateLimitingFilter;
     private final UserDetailsService userDetailsService;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+            RateLimitingFilter rateLimitingFilter,
             UserDetailsService userDetailsService) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.rateLimitingFilter = rateLimitingFilter;
         this.userDetailsService = userDetailsService;
     }
 
@@ -51,6 +56,14 @@ public class SecurityConfig {
     }
 
     @Bean
+    public FilterRegistrationBean<RateLimitingFilter> rateLimitingFilterRegistration(
+            RateLimitingFilter filter) {
+        FilterRegistrationBean<RateLimitingFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 // Disable CSRF — stateless REST API, no session cookies
@@ -62,6 +75,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // ── Public: Auth endpoints ───────────────────────
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/contact", "/api/contact/**", "/api/contacts", "/api/contacts/**").permitAll()
                         // ── Public: Swagger / OpenAPI ────────────────────
                         .requestMatchers(
                                 "/swagger-ui.html",
@@ -75,6 +89,8 @@ public class SecurityConfig {
                         // ── Everything else requires a valid JWT ─────────
                         .anyRequest().authenticated())
                 .authenticationProvider(authenticationProvider())
+                .addFilterBefore(rateLimitingFilter,
+                        UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/sandeep/eventrabackend/config/SwaggerConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SwaggerConfig.java
@@ -22,11 +22,16 @@ public class SwaggerConfig {
                         .title("Eventra API")
                         .description("""
                                 **Eventra** — Event Management Platform REST API.
-                                
+
                                 ### Authentication
                                 - Use `POST /api/auth/signup` to create an account.
                                 - Use `POST /api/auth/login` to obtain a JWT token.
                                 - Click **Authorize** and paste the token as `Bearer <token>` to test protected endpoints.
+
+                                ### Rate limiting
+                                Public auth/contact endpoints are rate limited by client IP.
+                                When a limit is exceeded, the API returns `429 Too Many Requests`
+                                with a standard error body and `Retry-After` header.
                                 """)
                         .version("v1.0.0")
                         .contact(new Contact()

--- a/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -52,6 +52,8 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "Validation error or passwords don't match",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "409", description = "Email already registered",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "429", description = "Signup rate limit exceeded",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<AuthResponse> signup(@Valid @RequestBody SignupRequest request) {
@@ -81,6 +83,8 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "Validation error — missing fields",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "401", description = "Invalid credentials",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "429", description = "Login rate limit exceeded",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {

--- a/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitResult.java
+++ b/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitResult.java
@@ -1,0 +1,4 @@
+package com.sandeep.eventrabackend.ratelimit;
+
+public record RateLimitResult(boolean allowed, int limit, int remaining, long retryAfterSeconds) {
+}

--- a/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitService.java
+++ b/src/main/java/com/sandeep/eventrabackend/ratelimit/RateLimitService.java
@@ -1,0 +1,59 @@
+package com.sandeep.eventrabackend.ratelimit;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class RateLimitService {
+
+    private final Clock clock;
+    private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+
+    public RateLimitService() {
+        this(Clock.systemUTC());
+    }
+
+    RateLimitService(Clock clock) {
+        this.clock = clock;
+    }
+
+    public RateLimitResult consume(String endpoint, String clientIp, int capacity, Duration window) {
+        if (capacity <= 0) {
+            return new RateLimitResult(false, capacity, 0, window.toSeconds());
+        }
+
+        String key = endpoint + ":" + clientIp;
+        Counter counter = counters.computeIfAbsent(key, ignored -> new Counter(clock.instant(), 0));
+
+        synchronized (counter) {
+            Instant now = clock.instant();
+            if (!now.isBefore(counter.windowStart.plus(window))) {
+                counter.windowStart = now;
+                counter.requests = 0;
+            }
+
+            if (counter.requests >= capacity) {
+                long retryAfter = Duration.between(now, counter.windowStart.plus(window)).toSeconds();
+                return new RateLimitResult(false, capacity, 0, Math.max(1, retryAfter));
+            }
+
+            counter.requests++;
+            return new RateLimitResult(true, capacity, capacity - counter.requests, 0);
+        }
+    }
+
+    private static class Counter {
+        private Instant windowStart;
+        private int requests;
+
+        private Counter(Instant windowStart, int requests) {
+            this.windowStart = windowStart;
+            this.requests = requests;
+        }
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/RateLimitingFilter.java
@@ -1,0 +1,136 @@
+package com.sandeep.eventrabackend.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.config.RateLimitProperties;
+import com.sandeep.eventrabackend.config.RateLimitProperties.EndpointLimit;
+import com.sandeep.eventrabackend.dto.response.ErrorResponse;
+import com.sandeep.eventrabackend.ratelimit.RateLimitResult;
+import com.sandeep.eventrabackend.ratelimit.RateLimitService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    private static final String POST = "POST";
+    private static final List<EndpointRule> ENDPOINT_RULES = List.of(
+            new EndpointRule("login", POST, "/api/auth/login"),
+            new EndpointRule("signup", POST, "/api/auth/signup"),
+            new EndpointRule("forgotPassword", POST, "/api/auth/forgot-password"),
+            new EndpointRule("forgotPassword", POST, "/api/auth/forgot-password/"),
+            new EndpointRule("contact", POST, "/api/contact"),
+            new EndpointRule("contact", POST, "/api/contact/"),
+            new EndpointRule("contact", POST, "/api/contacts"),
+            new EndpointRule("contact", POST, "/api/contacts/")
+    );
+
+    private final RateLimitProperties properties;
+    private final RateLimitService rateLimitService;
+    private final ObjectMapper objectMapper;
+
+    public RateLimitingFilter(RateLimitProperties properties,
+            RateLimitService rateLimitService,
+            ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.rateLimitService = rateLimitService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain)
+            throws ServletException, IOException {
+        EndpointRule endpointRule = findEndpointRule(request);
+        if (!properties.isEnabled() || endpointRule == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        EndpointLimit endpointLimit = limitFor(endpointRule.name());
+        String clientIp = resolveClientIp(request);
+        RateLimitResult result = rateLimitService.consume(
+                endpointRule.name(),
+                clientIp,
+                endpointLimit.getCapacity(),
+                endpointLimit.getWindow()
+        );
+
+        response.setHeader("X-RateLimit-Limit", String.valueOf(result.limit()));
+        response.setHeader("X-RateLimit-Remaining", String.valueOf(result.remaining()));
+
+        if (result.allowed()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        response.setHeader(HttpHeaders.RETRY_AFTER, String.valueOf(result.retryAfterSeconds()));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .status(HttpStatus.TOO_MANY_REQUESTS.value())
+                .error("Too Many Requests")
+                .message("Rate limit exceeded. Please try again after "
+                        + result.retryAfterSeconds() + " seconds.")
+                .path(request.getRequestURI())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        objectMapper.writeValue(response.getWriter(), errorResponse);
+    }
+
+    private EndpointRule findEndpointRule(HttpServletRequest request) {
+        String requestPath = request.getRequestURI();
+        String method = request.getMethod();
+
+        return ENDPOINT_RULES.stream()
+                .filter(rule -> rule.method().equalsIgnoreCase(method))
+                .filter(rule -> requestPath.equals(rule.path())
+                        || requestPath.startsWith(rule.path() + "/"))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private EndpointLimit limitFor(String endpointName) {
+        return switch (endpointName) {
+            case "login" -> properties.getLogin();
+            case "signup" -> properties.getSignup();
+            case "forgotPassword" -> properties.getForgotPassword();
+            case "contact" -> properties.getContact();
+            default -> throw new IllegalArgumentException("Unknown rate limit endpoint: " + endpointName);
+        };
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(forwardedFor)) {
+            String firstForwardedIp = forwardedFor.split(",")[0].trim();
+            if (StringUtils.hasText(firstForwardedIp)) {
+                return firstForwardedIp;
+            }
+        }
+
+        String realIp = request.getHeader("X-Real-IP");
+        if (StringUtils.hasText(realIp)) {
+            return realIp.trim();
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    private record EndpointRule(String name, String method, String path) {
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+app:
+  jwt:
+    secret: ${JWT_SECRET:change-this-secret-to-a-strong-256-bit-value-before-production}
+    expiration-ms: ${JWT_EXPIRATION_MS:86400000}
+  rate-limit:
+    enabled: ${RATE_LIMIT_ENABLED:true}
+    login:
+      capacity: ${RATE_LIMIT_LOGIN_CAPACITY:5}
+      window: ${RATE_LIMIT_LOGIN_WINDOW:1m}
+    signup:
+      capacity: ${RATE_LIMIT_SIGNUP_CAPACITY:3}
+      window: ${RATE_LIMIT_SIGNUP_WINDOW:10m}
+    forgot-password:
+      capacity: ${RATE_LIMIT_FORGOT_PASSWORD_CAPACITY:3}
+      window: ${RATE_LIMIT_FORGOT_PASSWORD_WINDOW:15m}
+    contact:
+      capacity: ${RATE_LIMIT_CONTACT_CAPACITY:5}
+      window: ${RATE_LIMIT_CONTACT_WINDOW:10m}

--- a/src/test/java/com/sandeep/eventrabackend/security/RateLimitingFilterTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/security/RateLimitingFilterTests.java
@@ -1,0 +1,52 @@
+package com.sandeep.eventrabackend.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "app.rate-limit.login.capacity=1",
+        "app.rate-limit.login.window=1m"
+})
+class RateLimitingFilterTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void returnsTooManyRequestsWhenLoginLimitIsExceeded() throws Exception {
+        String clientIp = "203.0.113.10";
+
+        mockMvc.perform(post("/api/auth/login")
+                        .header("X-Forwarded-For", clientIp)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+
+        mockMvc.perform(post("/api/auth/login")
+                        .header("X-Forwarded-For", clientIp)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists("Retry-After"))
+                .andExpect(header().string("X-RateLimit-Limit", "1"))
+                .andExpect(header().string("X-RateLimit-Remaining", "0"))
+                .andExpect(jsonPath("$.status", is(429)))
+                .andExpect(jsonPath("$.error", is("Too Many Requests")))
+                .andExpect(jsonPath("$.path", is("/api/auth/login")));
+    }
+}


### PR DESCRIPTION
## Description
Implements IP-based rate limiting for public backend endpoints to help protect against brute-force login attempts and spam requests.

## Changes
- Added configurable rate limits for:
  - Login
  - Signup
  - Forgot password
  - Contact APIs
- Added IP-based fixed-window rate limiting filter
- Returns `429 Too Many Requests` with:
  - Standard error response body
  - `Retry-After` header
  - `X-RateLimit-Limit`
  - `X-RateLimit-Remaining`
- Added environment-variable based configuration in `application.yml`
- Updated Swagger/OpenAPI docs with `429` responses
- Added MockMvc test coverage for login rate limiting

## Testing
```powershell
.\mvnw.cmd test