### PR TITLE
feat: Implement Bucket4j Rate Limiting for Authentication Endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.4.4</version>
-        <relativePath/> <!-- lookup parent from repository -->
-    </parent>
+        <relativePath/> </parent>
     <groupId>com.sandeep</groupId>
     <artifactId>Eventra-Backend</artifactId>
     <version>0.0.1-SNAPSHOT</version>
@@ -31,38 +30,32 @@
     </properties>
     <dependencies>
 
-        <!-- Spring Web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- Spring Security -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
-        <!-- Spring Data JPA -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
-        <!-- Validation -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
-        <!-- PostgreSQL Driver (Neon) -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
@@ -81,21 +74,24 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
 
-        <!-- SpringDoc OpenAPI (Swagger UI) -->
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.6</version>
         </dependency>
 
-        <!-- Test -->
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j-core</artifactId>
+            <version>8.1.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -107,7 +103,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- H2 in-memory DB for tests (no real Postgres needed in CI) -->
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/src/main/java/com/sandeep/eventrabackend/security/RateLimitFilter.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/RateLimitFilter.java
@@ -1,0 +1,45 @@
+package com.sandeep.eventrabackend.security;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    // Creates a bucket that allows exactly 15 requests every 1 minute
+    private final Bucket bucket = Bucket.builder()
+            .addLimit(Bandwidth.classic(15, Refill.intervally(15, Duration.ofMinutes(1))))
+            .build();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        // We only rate-limit authentication endpoints to prevent brute-force attacks
+        if (requestURI.startsWith("/api/auth")) {
+            if (!bucket.tryConsume(1)) {
+                // If they are out of tokens, block the request and return a 429 error
+                response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+                response.getWriter().write("Too many requests. Please try again in a minute.");
+                return;
+            }
+        }
+
+        // If they have tokens (or are visiting a non-auth page), let the request through
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces a robust rate-limiting security layer to protect the application's authentication endpoints from automated spam and brute-force credential stuffing. 

### Changes Made
* Added `bucket4j-core` dependency to `pom.xml`.
* Implemented `RateLimitFilter` extending `OncePerRequestFilter` within the `security` package.
* Configured an in-memory token bucket allowing **15 requests per minute** per instance.
* Intercepts requests targeting `/api/auth/**`. Excess requests immediately return a clean `429 Too Many Requests` HTTP status, preventing them from hitting the database.
* Non-authentication routes remain unaffected.

Fixes #1235