### PR TITLE
Fix: Implement Stateless JWT Logout with Token Blacklisting

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/EventraBackendApplication.java
+++ b/src/main/java/com/sandeep/eventrabackend/EventraBackendApplication.java
@@ -2,8 +2,10 @@ package com.sandeep.eventrabackend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling; // 1. Added import
 
 @SpringBootApplication
+@EnableScheduling // 2. Added annotation to turn on background cleanup
 public class EventraBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/JwtAuthenticationFilter.java
@@ -24,20 +24,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
+    private final TokenBlacklistService tokenBlacklistService; // 1. Add the blacklist service
 
+    // 2. Add the blacklist service to the constructor
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
-            UserDetailsService userDetailsService) {
+                                   UserDetailsService userDetailsService,
+                                   TokenBlacklistService tokenBlacklistService) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.userDetailsService = userDetailsService;
+        this.tokenBlacklistService = tokenBlacklistService;
     }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
-            HttpServletResponse response,
-            FilterChain filterChain)
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
             throws ServletException, IOException {
         try {
             String token = extractTokenFromRequest(request);
+
+            // 3. BLOCK BLACKLISTED TOKENS HERE
+            if (StringUtils.hasText(token) && tokenBlacklistService.isBlacklisted(token)) {
+                logger.warn("Attempt to use blacklisted token.");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Token has been revoked/logged out");
+                return; // Stop processing the request
+            }
 
             if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
                 String username = jwtTokenProvider.getUsernameFromToken(token);
@@ -51,8 +63,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception ex) {
-            // Log but do NOT rethrow — let the request continue.
-            // permitAll() endpoints must not be blocked by a bad/stale token.
             logger.warn("Could not authenticate from JWT token: {}", ex.getMessage());
             SecurityContextHolder.clearContext();
         }

--- a/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
@@ -60,6 +60,16 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
+    // NEW METHOD: Extracts the expiration date for the logout blacklist
+    public Date getExpirationDateFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parser()

--- a/src/main/java/com/sandeep/eventrabackend/security/TokenBlacklistService.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/TokenBlacklistService.java
@@ -1,0 +1,30 @@
+package com.sandeep.eventrabackend.security;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class TokenBlacklistService {
+
+    // Key: JWT token, Value: Token expiration date
+    private final Map<String, Date> blacklist = new ConcurrentHashMap<>();
+
+    public void addToBlacklist(String token, Date expiration) {
+        blacklist.put(token, expiration);
+    }
+
+    public boolean isBlacklisted(String token) {
+        return blacklist.containsKey(token);
+    }
+
+    // Clean up expired tokens every hour to prevent memory leaks
+    @Scheduled(fixedRate = 3600000)
+    public void cleanUpBlacklist() {
+        Date now = new Date();
+        blacklist.entrySet().removeIf(entry -> entry.getValue().before(now));
+    }
+}


### PR DESCRIPTION
## Description
This PR resolves the issue where stateless JWT tokens remained valid even after a user logged out. 

Since adding a Redis caching dependency was not required, this implementation introduces an in-memory token blacklist using `ConcurrentHashMap` to block logged-out tokens until their natural expiration.

## Changes Made
* **TokenBlacklistService:** Created a service to manage the `ConcurrentHashMap` blacklist.
* **Scheduled Cleanup:** Added an hourly `@Scheduled` task to remove naturally expired tokens from the map, preventing memory leaks. Enabled scheduling in the main application class.
* **JwtTokenProvider:** Added a helper method to extract the expiration date from the token.
* **JwtAuthenticationFilter:** Intercepts incoming requests and returns a `401 Unauthorized` if the provided token exists in the blacklist.
* **AuthController:** Implemented the `/logout` endpoint to extract the token, read its expiration date, and add it to the blacklist.

Closes #1431