### PR TITLE
fix(event-registration): prevent concurrent overbooking with optimist…

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/exception/EventFullException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/EventFullException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class EventFullException extends RuntimeException {
+    public EventFullException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -61,6 +61,20 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(EventFullException.class)
+    public ResponseEntity<ErrorResponse> handleEventFull(
+            EventFullException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(RegistrationConflictException.class)
+    public ResponseEntity<ErrorResponse> handleRegistrationConflict(
+            RegistrationConflictException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleGenericException(
             Exception ex,

--- a/src/main/java/com/sandeep/eventrabackend/exception/RegistrationConflictException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/RegistrationConflictException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class RegistrationConflictException extends RuntimeException {
+    public RegistrationConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -11,15 +11,23 @@ public class Event {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     private String title;
     private String description;
     private String location;
     private LocalDateTime eventDate;
     private boolean isPublic = true;
+    private int maxAttendees;
+    private int currentAttendees;
 
     // Getters and Setters
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+
+    public Long getVersion() { return version; }
+    public void setVersion(Long version) { this.version = version; }
 
     public String getTitle() { return title; }
     public void setTitle(String title) { this.title = title; }
@@ -35,4 +43,10 @@ public class Event {
 
     public boolean isPublic() { return isPublic; }
     public void setPublic(boolean isPublic) { this.isPublic = isPublic; }
+
+    public int getMaxAttendees() { return maxAttendees; }
+    public void setMaxAttendees(int maxAttendees) { this.maxAttendees = maxAttendees; }
+
+    public int getCurrentAttendees() { return currentAttendees; }
+    public void setCurrentAttendees(int currentAttendees) { this.currentAttendees = currentAttendees; }
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,9 +1,13 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.exception.EventFullException;
 import com.sandeep.eventrabackend.exception.EventNotFoundException;
+import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -18,5 +22,24 @@ public class EventService {
     public Event getPublicEventById(long id) {
         return eventRepository.findByIdAndIsPublicTrue(id)
                 .orElseThrow(() -> new EventNotFoundException("Event not found or is not public with id: " + id));
+    }
+
+    @Transactional
+    public void registerForEvent(Long eventId, Long userId) {
+        try {
+            Event event = eventRepository.findById(eventId)
+                    .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+
+            if (event.getCurrentAttendees() >= event.getMaxAttendees()) {
+                throw new EventFullException("This event has reached capacity.");
+            }
+
+            event.setCurrentAttendees(event.getCurrentAttendees() + 1);
+            eventRepository.saveAndFlush(event);
+        } catch (OptimisticLockingFailureException ex) {
+            throw new RegistrationConflictException(
+                    "Too many simultaneous registrations. Please try again."
+            );
+        }
     }
 }

--- a/src/test/java/com/sandeep/eventrabackend/service/EventRegistrationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/sandeep/eventrabackend/service/EventRegistrationConcurrencyIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.exception.EventFullException;
+import com.sandeep.eventrabackend.exception.RegistrationConflictException;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class EventRegistrationConcurrencyIntegrationTest {
+
+    @Autowired
+    private EventService eventService;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @BeforeEach
+    void setUp() {
+        eventRepository.deleteAll();
+    }
+
+    @Test
+    void shouldPreventConcurrentOverbookingWhenCapacityIsOne() throws InterruptedException {
+        int threads = 20;
+        Event event = createEventWithCapacity(1);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+
+        for (int i = 0; i < threads; i++) {
+            final long userId = i + 1L;
+            executor.submit(() -> {
+                try {
+                    ready.countDown();
+                    start.await();
+                    eventService.registerForEvent(event.getId(), userId);
+                    successCount.incrementAndGet();
+                } catch (EventFullException | RegistrationConflictException ex) {
+                    failureCount.incrementAndGet();
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+        executor.shutdown();
+
+        Event updated = eventRepository.findById(event.getId()).orElseThrow();
+        assertEquals(1, updated.getCurrentAttendees());
+        assertEquals(1, successCount.get());
+        assertEquals(threads - 1, failureCount.get());
+    }
+
+    private Event createEventWithCapacity(int capacity) {
+        Event event = new Event();
+        event.setTitle("Concurrency Test Event");
+        event.setDescription("Testing optimistic locking for registrations");
+        event.setLocation("Online");
+        event.setEventDate(LocalDateTime.now().plusDays(1));
+        event.setPublic(true);
+        event.setMaxAttendees(capacity);
+        event.setCurrentAttendees(0);
+        return eventRepository.saveAndFlush(event);
+    }
+}


### PR DESCRIPTION
# Summary

This PR fixes a critical race condition in event registration that could overbook events during concurrent registration requests.

Previously, multiple users registering simultaneously could pass the same capacity check before any transaction committed, causing attendee counts to exceed the configured event capacity.

This fix introduces JPA optimistic locking along with proper conflict handling to guarantee registration integrity under concurrent load.

---

# Problem

Concurrent requests could all read the same attendee count before any write was committed.

Example:

* Event capacity = 100
* Current attendees = 99
* Multiple concurrent requests read `99`
* All requests pass validation
* Multiple registrations succeed for the final remaining slot

Result:

* Event becomes overbooked
* Data integrity is compromised

---

# Changes Made

## 1. Added Optimistic Locking to `Event`

Added JPA optimistic locking support using:

```java
@Version
private Long version;
```

This ensures concurrent updates on the same event row are detected by Hibernate.

---

## 2. Added Capacity Enforcement Fields

Added:

* `maxAttendees`
* `currentAttendees`

These fields are used to enforce strict registration limits.

---

## 3. Added Concurrent-Safe Registration Flow

Implemented `registerForEvent(Long eventId, Long userId)` with:

* `@Transactional`
* Capacity validation
* Atomic attendee increment
* `saveAndFlush(...)`
* Optimistic locking conflict handling

The flow now prevents simultaneous requests from exceeding event capacity.

---

## 4. Added Custom Exceptions

### `EventFullException`

Thrown when an event has already reached maximum capacity.

### `RegistrationConflictException`

Thrown when concurrent registration conflicts occur due to optimistic locking.

---

# 5. Added HTTP 409 Conflict Responses

Updated `GlobalExceptionHandler` with:

* `EventFullException -> HTTP 409 CONFLICT`
* `RegistrationConflictException -> HTTP 409 CONFLICT`

This provides clear API responses for clients during capacity conflicts.

---

# 6. Added Concurrent Registration Integration Test

Added a multithreaded integration test using:

* `ExecutorService`
* `CountDownLatch`

Test scenario:

* Event capacity = 1
* 20 concurrent registration attempts

Assertions:

* Exactly one registration succeeds
* `currentAttendees == 1`
* Remaining requests fail gracefully with conflict/full-capacity behavior

---

# Why This Fix Matters

* Prevents silent event overbooking
* Preserves database consistency
* Handles real-world traffic spikes safely
* Provides predictable conflict responses to clients

---

# Scope

* Backend-only change
* Focused strictly on registration concurrency and capacity enforcement
* No unrelated module modifications

---

# Related Issue

Closes #1444
