### PR TITLE
feat: add event capacity enforcement and concurrency-safe registration

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -1,13 +1,18 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.service.EventService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 
 @RestController
 @RequestMapping("/api/events")
+@Tag(name = "Events", description = "Endpoints for managing and interacting with events")
 public class EventController {
 
     private final EventService eventService;
@@ -18,8 +23,24 @@ public class EventController {
 
 
     @GetMapping("/{id}")
+    @Operation(summary = "Get a public event by ID")
     public ResponseEntity<Event> getPublicEventById(@PathVariable Long id) {
         Event event = eventService.getPublicEventById(id);
         return ResponseEntity.ok(event);
+    }
+
+    @PostMapping("/{id}/register")
+    @Operation(summary = "Register the currently authenticated user for an event")
+    public ResponseEntity<Event> registerForEvent(@PathVariable Long id, Authentication authentication) {
+        String userEmail = authentication.getName();
+        Event event = eventService.registerUserForEvent(id, userEmail);
+        return ResponseEntity.ok(event);
+    }
+
+    @GetMapping("/{id}/availability")
+    @Operation(summary = "Get the availability (spots left) for an event")
+    public ResponseEntity<EventAvailabilityResponse> getEventAvailability(@PathVariable Long id) {
+        EventAvailabilityResponse response = eventService.getEventAvailability(id);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/EventAvailabilityResponse.java
@@ -1,0 +1,17 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventAvailabilityResponse {
+    private Integer capacity;
+    private int registeredCount;
+    private Integer spotsLeft;
+    private boolean isFull;
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/EventFullException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/EventFullException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class EventFullException extends RuntimeException {
+    public EventFullException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +21,21 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(EventFullException.class)
+    public ResponseEntity<ErrorResponse> handleEventFull(
+            EventFullException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponse> handleOptimisticLockingFailure(
+            ObjectOptimisticLockingFailureException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.CONFLICT, "Conflict", 
+                "The event was updated by another user. Please try again.", request);
+    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationErrors(

--- a/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -2,6 +2,8 @@ package com.sandeep.eventrabackend.model;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "events")
@@ -16,6 +18,20 @@ public class Event {
     private String location;
     private LocalDateTime eventDate;
     private boolean isPublic = true;
+
+    private Integer capacity;
+    private int registeredCount = 0;
+
+    @Version
+    private Long version;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "event_attendees",
+            joinColumns = @JoinColumn(name = "event_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> attendees = new HashSet<>();
 
     // Getters and Setters
     public Long getId() { return id; }
@@ -35,4 +51,16 @@ public class Event {
 
     public boolean isPublic() { return isPublic; }
     public void setPublic(boolean isPublic) { this.isPublic = isPublic; }
+
+    public Integer getCapacity() { return capacity; }
+    public void setCapacity(Integer capacity) { this.capacity = capacity; }
+
+    public int getRegisteredCount() { return registeredCount; }
+    public void setRegisteredCount(int registeredCount) { this.registeredCount = registeredCount; }
+
+    public Long getVersion() { return version; }
+    public void setVersion(Long version) { this.version = version; }
+
+    public Set<User> getAttendees() { return attendees; }
+    public void setAttendees(Set<User> attendees) { this.attendees = attendees; }
 }

--- a/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -1,11 +1,19 @@
 package com.sandeep.eventrabackend.repository;
 
 import com.sandeep.eventrabackend.model.Event;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
     Optional<Event> findByIdAndIsPublicTrue(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT e FROM Event e WHERE e.id = :id")
+    Optional<Event> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,22 +1,77 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
+import com.sandeep.eventrabackend.exception.EventFullException;
 import com.sandeep.eventrabackend.exception.EventNotFoundException;
 import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
 public class EventService {
 
     private final EventRepository eventRepository;
+    private final UserRepository userRepository;
 
-    public EventService(EventRepository eventRepository) {
+    public EventService(EventRepository eventRepository, UserRepository userRepository) {
         this.eventRepository = eventRepository;
+        this.userRepository = userRepository;
     }
 
     public Event getPublicEventById(long id) {
         return eventRepository.findByIdAndIsPublicTrue(id)
                 .orElseThrow(() -> new EventNotFoundException("Event not found or is not public with id: " + id));
+    }
+
+    @Transactional
+    public Event registerUserForEvent(Long eventId, String userEmail) {
+        return executeRegistration(eventId, userEmail);
+    }
+
+    private Event executeRegistration(Long eventId, String userEmail) {
+        // Use pessimistic lock to ensure thread safety and prevent overbooking
+        Event event = eventRepository.findByIdWithLock(eventId)
+                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + eventId));
+
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
+
+        // If user is already registered, follow existing behavior (just return the event)
+        if (event.getAttendees().contains(user)) {
+            return event;
+        }
+
+        // Check capacity
+        if (event.getCapacity() != null && event.getRegisteredCount() >= event.getCapacity()) {
+            throw new EventFullException("Event is already full. Capacity: " + event.getCapacity());
+        }
+
+        // Increment count and add user
+        event.getAttendees().add(user);
+        event.setRegisteredCount(event.getAttendees().size());
+
+        return eventRepository.save(event);
+    }
+
+    public EventAvailabilityResponse getEventAvailability(Long id) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
+
+        Integer capacity = event.getCapacity();
+        int registeredCount = event.getRegisteredCount();
+        Integer spotsLeft = (capacity == null) ? null : Math.max(0, capacity - registeredCount);
+        boolean isFull = (capacity != null) && (registeredCount >= capacity);
+
+        return EventAvailabilityResponse.builder()
+                .capacity(capacity)
+                .registeredCount(registeredCount)
+                .spotsLeft(spotsLeft)
+                .isFull(isFull)
+                .build();
     }
 }

--- a/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/EventRegistrationTests.java
@@ -1,0 +1,125 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class EventRegistrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Long eventId;
+
+    @BeforeEach
+    void setUp() {
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        Event event = new Event();
+        event.setTitle("Test Event");
+        event.setCapacity(5);
+        event.setEventDate(LocalDateTime.now().plusDays(1));
+        event = eventRepository.save(event);
+        eventId = event.getId();
+
+        for (int i = 1; i <= 10; i++) {
+            User user = User.builder()
+                    .firstName("User" + i)
+                    .lastName("Test")
+                    .email("user" + i + "@example.com")
+                    .username("user" + i)
+                    .password("password")
+                    .role(Role.CLIENT)
+                    .build();
+            userRepository.save(user);
+        }
+    }
+
+    @Test
+    void testConcurrentRegistration() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch finishLatch = new CountDownLatch(threadCount);
+        
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger conflictCount = new AtomicInteger(0);
+
+        for (int i = 1; i <= threadCount; i++) {
+            final String email = "user" + i + "@example.com";
+            executorService.execute(() -> {
+                try {
+                    latch.await();
+                    int status = mockMvc.perform(post("/api/events/" + eventId + "/register")
+                            .with(user(email)))
+                            .andReturn().getResponse().getStatus();
+                    
+                    if (status == 200) {
+                        successCount.incrementAndGet();
+                    } else if (status == 409) {
+                        conflictCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    finishLatch.countDown();
+                }
+            });
+        }
+
+        latch.countDown();
+        finishLatch.await();
+        executorService.shutdown();
+
+        assertEquals(5, successCount.get(), "Should have exactly 5 successful registrations");
+        
+        Event event = eventRepository.findById(eventId).orElseThrow();
+        assertEquals(5, event.getRegisteredCount(), "Final registeredCount should be 5");
+    }
+
+    @Test
+    @WithMockUser(username = "user1@example.com")
+    void testAvailabilityEndpoint() throws Exception {
+        mockMvc.perform(get("/api/events/" + eventId + "/availability"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.capacity").value(5))
+                .andExpect(jsonPath("$.registeredCount").value(0))
+                .andExpect(jsonPath("$.spotsLeft").value(5))
+                .andExpect(jsonPath("$.full").value(false));
+    }
+}


### PR DESCRIPTION
## Related Issue

Fixes SandeepVashishtha/Eventra#1502

---

## Description

Implemented backend-side event capacity enforcement to prevent overbooking during concurrent registrations.

### Changes Made
- Added event capacity and registered count tracking
- Implemented synchronized registration flow using pessimistic locking
- Prevented concurrent overbooking during simultaneous registrations
- Added `EventFullException` with HTTP 409 Conflict handling
- Added event availability endpoint:
  `GET /api/events/{id}/availability`
- Added concurrency test coverage for simultaneous registration attempts
- Preserved existing duplicate-registration behavior and validation flow

---

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [x] Security enhancement
- [ ] Other (specify): _______________

---

## Testing

Successfully tested the implementation using the Maven test suite.

**Command used:**

```powershell
.\mvnw.cmd -Dtest=EventRegistrationTests test
```

**Result:**
- All tests passed successfully
- Concurrent registration test validated proper seat enforcement
- Verified no overbooking under simultaneous registration attempts
- BUILD SUCCESS achieved

---

## Test Output Screenshot

<details>
<summary>Click to view test result screenshot</summary>

<br />

<img src="https://github.com/user-attachments/assets/1193c1df-ed91-4873-a9c9-86a4936db5b5" alt="Maven test build success" width="650" />

</details>

---

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing conflicts before submitting this PR.