### PR TITLE
fix: fetch events by id without public-only filtering

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -23,9 +23,9 @@ public class EventController {
 
 
     @GetMapping("/{id}")
-    @Operation(summary = "Get a public event by ID")
-    public ResponseEntity<Event> getPublicEventById(@PathVariable Long id) {
-        Event event = eventService.getPublicEventById(id);
+    @Operation(summary = "Get an event by ID")
+    public ResponseEntity<Event> getEventById(@PathVariable Long id) {
+        Event event = eventService.getEventById(id);
         return ResponseEntity.ok(event);
     }
 

--- a/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
-    Optional<Event> findByIdAndIsPublicTrue(Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e FROM Event e WHERE e.id = :id")

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -24,9 +24,9 @@ public class EventService {
         this.userRepository = userRepository;
     }
 
-    public Event getPublicEventById(long id) {
-        return eventRepository.findByIdAndIsPublicTrue(id)
-                .orElseThrow(() -> new EventNotFoundException("Event not found or is not public with id: " + id));
+    public Event getEventById(Long id) {
+        return eventRepository.findById(id)
+                .orElseThrow(() -> new EventNotFoundException("Event not found with id: " + id));
     }
 
     @Transactional

--- a/src/test/java/com/sandeep/eventrabackend/controller/GetEventByIdTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/GetEventByIdTests.java
@@ -1,0 +1,79 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class GetEventByIdTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    private Long publicEventId;
+    private Long privateEventId;
+
+    @BeforeEach
+    void setUp() {
+        eventRepository.deleteAll();
+
+        Event publicEvent = new Event();
+        publicEvent.setTitle("Public Event");
+        publicEvent.setPublic(true);
+        publicEvent.setEventDate(LocalDateTime.now().plusDays(1));
+        publicEvent = eventRepository.save(publicEvent);
+        publicEventId = publicEvent.getId();
+
+        Event privateEvent = new Event();
+        privateEvent.setTitle("Private Event");
+        privateEvent.setPublic(false);
+        privateEvent.setEventDate(LocalDateTime.now().plusDays(2));
+        privateEvent = eventRepository.save(privateEvent);
+        privateEventId = privateEvent.getId();
+    }
+
+    @Test
+    @WithMockUser
+    void testGetPublicEventById() throws Exception {
+        mockMvc.perform(get("/api/events/" + publicEventId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Public Event"))
+                .andExpect(jsonPath("$.public").value(true));
+    }
+
+    @Test
+    @WithMockUser
+    void testGetPrivateEventById() throws Exception {
+        // This should pass after implementation. Currently it might fail (return 404).
+        mockMvc.perform(get("/api/events/" + privateEventId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Private Event"))
+                .andExpect(jsonPath("$.public").value(false));
+    }
+
+    @Test
+    @WithMockUser
+    void testGetNonExistentEventById() throws Exception {
+        mockMvc.perform(get("/api/events/999999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Event not found with id: 999999"));
+    }
+}


### PR DESCRIPTION
## Related Issue

Fixes SandeepVashishtha/Eventra#2097

## Description

Updated the existing `GET /api/events/{id}` endpoint to retrieve events directly by ID instead of using the previous public-only lookup.

Previously, the endpoint only returned events where `public=true`, causing valid private/non-public events to return `404 Not Found`. This PR restores the expected get-by-ID behavior while keeping missing-event handling intact.

## Changes Made

- Updated `EventController` to call `eventService.getEventById(id)`
- Updated `EventService` to use `eventRepository.findById(id)`
- Removed the unused public-only repository lookup
- Added focused tests for:
  - fetching a public event by ID
  - fetching a private event by ID
  - returning `404 Not Found` for a missing event ID

## Testing

- [x] `.\mvnw.cmd "-Dtest=GetEventByIdTests" test`
- [x] `.\mvnw.cmd clean test`
- [x] Manually verified authenticated event retrieval using temporary local H2 seed data

## Manual Verification

Verified locally with JWT authentication using temporary H2 seed data:

- `GET /api/events/1` returned `200 OK` for a public event
- `GET /api/events/2` returned `200 OK` for a private event
- `GET /api/events/999999` returned `404 Not Found` with `Event not found with id: 999999`

This confirms the endpoint now fetches events directly by ID instead of using the previous public-only lookup.

<details>
<summary><strong>Public Event Retrieval</strong></summary>

<br>

<p align="center">
  <a href="https://github.com/user-attachments/assets/24ddf34f-6d42-46b6-a847-febe8c4d8a8a">
    <img src="https://github.com/user-attachments/assets/24ddf34f-6d42-46b6-a847-febe8c4d8a8a" width="600" />
  </a>
</p>

</details>

<details>
<summary><strong>Private Event Retrieval</strong></summary>

<br>

<p align="center">
  <a href="https://github.com/user-attachments/assets/9239f635-bacf-4bff-8313-cc5cd718edaf">
    <img src="https://github.com/user-attachments/assets/9239f635-bacf-4bff-8313-cc5cd718edaf" width="600" />
  </a>
</p>

</details>

<details>
<summary><strong>Missing Event Handling</strong></summary>

<br>

<p align="center">
  <a href="https://github.com/user-attachments/assets/6e5ea46d-1ddc-4c36-8ad1-f63a4d326cbf">
    <img src="https://github.com/user-attachments/assets/6e5ea46d-1ddc-4c36-8ad1-f63a4d326cbf" width="600" />
  </a>
</p>

</details>

<details>
<summary><strong>Automated Test Results</strong></summary>

<br>

<p align="center">
  <a href="https://github.com/user-attachments/assets/cd3a159a-5a6d-4054-a248-50815675b389">
    <img src="https://github.com/user-attachments/assets/cd3a159a-5a6d-4054-a248-50815675b389" width="600" />
  </a>
</p>

</details>