### PR TITLE
feat: prevent duplicate registration with service check and database …

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/model/Event.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Event.java
@@ -42,9 +42,10 @@ public class Event {
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-            name = "event_attendees",
-            joinColumns = @JoinColumn(name = "event_id"),
-            inverseJoinColumns = @JoinColumn(name = "user_id")
+        name = "event_attendees",
+        joinColumns = @JoinColumn(name = "event_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id"),
+        uniqueConstraints = @UniqueConstraint(columnNames = {"event_id", "user_id"})
     )
     private Set<User> attendees = new HashSet<>();
 

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -165,9 +165,13 @@ public class EventService {
                         new UsernameNotFoundException(
                                 "User not found with email: " + userEmail));
 
-        if (event.getAttendees().contains(user)) {
-            throw new RegistrationConflictException(
-                    "You are already registered for this event.");
+        // Check unique user-event registration by matching user IDs inside the attendees list
+        boolean isAlreadyRegistered = event.getAttendees().stream()
+        .anyMatch(attendee -> attendee.getId().equals(user.getId()));
+
+        if (isAlreadyRegistered) {
+                throw new RegistrationConflictException(
+                        "You are already registered for this event.");
         }
 
         if (event.getCapacity() != null


### PR DESCRIPTION
### Description
Fixes the issue where users were able to register multiple times for the same event, causing duplicate entries.

### Key Changes
1. **Service Level Check (`EventService.java`)**: 
   - Replaced the weak `.contains(user)` check with an explicit Java Stream `.anyMatch()` verification matching the user IDs.
   - Throws a `RegistrationConflictException` if a match is found, which correctly returns an **HTTP 409 Conflict** response.

2. **Database Level Constraint (`Event.java`)**:
   - Added a `@UniqueConstraint(columnNames = {"event_id", "user_id"})` on the `event_attendees` join table to prevent duplicate inserts at the database level during race conditions.

### Acceptance Criteria Met
- [x] Duplicate registration blocked
- [x] Proper conflict message returned (409 Conflict)
- [x] Existing registrations remain unaffected