### PR TITLE
feat: add update event API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
+import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
@@ -83,6 +84,61 @@ public class EventController {
 
         Event createdEvent = eventService.createEvent(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdEvent);
+    }
+
+    // ── Issue #2099 — PUT /api/events/{id} ──────────────────────────────────
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN')")
+    @Operation(
+            summary = "Update an existing event",
+            description = "Allows an ORGANIZER or ADMIN to update event details.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Event updated successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = Event.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid payload (validation failed)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User does not have ORGANIZER or ADMIN role",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Event not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<Event> updateEvent(
+            @Parameter(description = "ID of the event to update")
+            @PathVariable Long id,
+            @Valid @RequestBody EventUpdateRequest request) {
+
+        Event updatedEvent = eventService.updateEvent(id, request);
+        return ResponseEntity.ok(updatedEvent);
     }
 
     // ── Issue #2101 — GET /api/events/{id} ──────────────────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
@@ -1,0 +1,45 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request payload for updating an existing event")
+public class EventUpdateRequest {
+
+    @NotBlank(message = "Title is required")
+    @Schema(description = "Event title", example = "Tech Conference 2026 Updated")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    @Schema(description = "Detailed event description", example = "An updated deep dive into AI and Cloud computing.")
+    private String description;
+
+    @NotBlank(message = "Location is required")
+    @Schema(description = "Physical or virtual location", example = "San Jose, CA")
+    private String location;
+
+    @NotNull(message = "Event date is required")
+    @Future(message = "Event date must be in the future")
+    @Schema(description = "Date and time when the event starts")
+    private LocalDateTime eventDate;
+
+    @Positive(message = "Capacity must be positive")
+    @Schema(description = "Maximum number of attendees allowed (null for unlimited)", example = "150")
+    private Integer capacity;
+
+    @Schema(description = "Whether the event is publicly visible", defaultValue = "true")
+    private Boolean isPublic;
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
+import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
@@ -151,6 +152,37 @@ public class EventService {
 
         // Ensure registeredCount is 0 for new events
         event.setRegisteredCount(0);
+
+        return eventRepository.save(event);
+    }
+
+    /**
+     * Updates an existing event.
+     *
+     * @param id ID of the event to update
+     * @param request updated event details
+     * @return the updated event
+     * @throws EventNotFoundException if the event does not exist
+     */
+    @Transactional
+    public Event updateEvent(Long id, EventUpdateRequest request) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() ->
+                        new EventNotFoundException("Event not found with id: " + id));
+
+        // Business Rule: Capacity cannot be less than current registrations
+        if (request.getCapacity() != null && request.getCapacity() < event.getRegisteredCount()) {
+            throw new RegistrationConflictException(
+                    "Capacity cannot be reduced below the current number of registered users ("
+                    + event.getRegisteredCount() + ")");
+        }
+
+        event.setTitle(request.getTitle());
+        event.setDescription(request.getDescription());
+        event.setLocation(request.getLocation());
+        event.setEventDate(request.getEventDate());
+        event.setCapacity(request.getCapacity());
+        event.setPublic(request.getIsPublic() == null || request.getIsPublic());
 
         return eventRepository.save(event);
     }

--- a/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/EventUpdateTests.java
@@ -1,7 +1,8 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
+import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
+import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
@@ -21,14 +22,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-public class EventCreationTests {
+public class EventUpdateTests {
 
     @Autowired
     private MockMvc mockMvc;
@@ -48,13 +49,15 @@ public class EventCreationTests {
     @Autowired
     private ObjectMapper objectMapper;
 
+    private Event existingEvent;
+
     @BeforeEach
     void setUp() {
         eventRegistrationRepository.deleteAll();
         eventRepository.deleteAll();
         userRepository.deleteAll();
 
-        // Create users with different roles
+        // Create users
         userRepository.save(User.builder()
                 .firstName("Admin")
                 .lastName("User")
@@ -81,76 +84,71 @@ public class EventCreationTests {
                 .password(passwordEncoder.encode("password"))
                 .role(Role.CLIENT)
                 .build());
+
+        // Create an existing event
+        Event event = new Event();
+        event.setTitle("Original Title");
+        event.setDescription("Original Description");
+        event.setLocation("Original Location");
+        event.setEventDate(LocalDateTime.now().plusDays(5));
+        event.setCapacity(100);
+        event.setPublic(true);
+        existingEvent = eventRepository.save(event);
     }
 
     @Test
-    @DisplayName("ORGANIZER can create event and gets 201")
-    void testOrganizerCanCreateEvent() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
-                .title("Organizer Event")
-                .description("Description")
-                .location("Location")
-                .eventDate(LocalDateTime.now().plusDays(1))
-                .capacity(100)
-                .isPublic(true)
+    @DisplayName("ORGANIZER can update event successfully")
+    void testOrganizerCanUpdateEvent() throws Exception {
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Updated Title")
+                .description("Updated Description")
+                .location("Updated Location")
+                .eventDate(LocalDateTime.now().plusDays(10))
+                .capacity(150)
+                .isPublic(false)
                 .build();
 
-        mockMvc.perform(post("/api/events/create")
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
                         .with(user("organizer@example.com").authorities(() -> "ORGANIZER"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.title").value("Organizer Event"))
-                .andExpect(jsonPath("$.registeredCount").value(0));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Updated Title"))
+                .andExpect(jsonPath("$.public").value(false))
+                .andExpect(jsonPath("$.capacity").value(150));
     }
 
     @Test
-    @DisplayName("ADMIN can create event and gets 201")
-    void testAdminCanCreateEvent() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
-                .title("Admin Event")
-                .description("Description")
-                .location("Location")
-                .eventDate(LocalDateTime.now().plusDays(1))
-                .capacity(50)
+    @DisplayName("ADMIN can update event successfully")
+    void testAdminCanUpdateEvent() throws Exception {
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Admin Updated Title")
+                .description("Updated Description")
+                .location("Updated Location")
+                .eventDate(LocalDateTime.now().plusDays(10))
+                .capacity(200)
                 .isPublic(true)
                 .build();
 
-        mockMvc.perform(post("/api/events/create")
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
                         .with(user("admin@example.com").authorities(() -> "ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.title").value("Admin Event"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Admin Updated Title"));
     }
 
     @Test
-    @DisplayName("unauthenticated request gets 401")
-    void testUnauthenticatedRequest() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
-                .title("Unauth Event")
+    @DisplayName("CLIENT cannot update event - 403 Forbidden")
+    void testClientCannotUpdateEvent() throws Exception {
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Client Update Attempt")
                 .description("Description")
                 .location("Location")
-                .eventDate(LocalDateTime.now().plusDays(1))
+                .eventDate(LocalDateTime.now().plusDays(10))
                 .build();
 
-        mockMvc.perform(post("/api/events/create")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    @DisplayName("CLIENT request gets 403")
-    void testClientRequestForbidden() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
-                .title("Client Event")
-                .description("Description")
-                .location("Location")
-                .eventDate(LocalDateTime.now().plusDays(1))
-                .build();
-
-        mockMvc.perform(post("/api/events/create")
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
                         .with(user("client@example.com").authorities(() -> "CLIENT"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -158,9 +156,27 @@ public class EventCreationTests {
     }
 
     @Test
-    @DisplayName("invalid payload gets 400")
-    void testInvalidPayload() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
+    @DisplayName("Missing event returns 404")
+    void testUpdateNonExistentEvent() throws Exception {
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Updated Title")
+                .description("Description")
+                .location("Location")
+                .eventDate(LocalDateTime.now().plusDays(10))
+                .build();
+
+        mockMvc.perform(put("/api/events/999")
+                        .with(user("admin@example.com").authorities(() -> "ADMIN"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Event not found with id: 999"));
+    }
+
+    @Test
+    @DisplayName("Invalid payload returns 400")
+    void testUpdateWithInvalidPayload() throws Exception {
+        EventUpdateRequest request = EventUpdateRequest.builder()
                 .title("") // Blank title
                 .description("Description")
                 .location("Location")
@@ -168,7 +184,7 @@ public class EventCreationTests {
                 .capacity(-10) // Negative capacity
                 .build();
 
-        mockMvc.perform(post("/api/events/create")
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
                         .with(user("admin@example.com").authorities(() -> "ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -176,39 +192,25 @@ public class EventCreationTests {
     }
 
     @Test
-    @DisplayName("omitted isPublic defaults to true")
-    void testOmittedIsPublicDefaultsToTrue() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
-                .title("Default Public Event")
+    @DisplayName("Capacity lower than registeredCount returns 409 (Conflict)")
+    void testUpdateCapacityLowerThanRegisteredCount() throws Exception {
+        // Manually set registeredCount for the event
+        existingEvent.setRegisteredCount(10);
+        eventRepository.save(existingEvent);
+
+        EventUpdateRequest request = EventUpdateRequest.builder()
+                .title("Capacity Update")
                 .description("Description")
                 .location("Location")
-                .eventDate(LocalDateTime.now().plusDays(1))
+                .eventDate(LocalDateTime.now().plusDays(5))
+                .capacity(5) // Less than registeredCount(10)
+                .isPublic(true)
                 .build();
 
-        mockMvc.perform(post("/api/events/create")
+        mockMvc.perform(put("/api/events/" + existingEvent.getId())
                         .with(user("admin@example.com").authorities(() -> "ADMIN"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.public").value(true)); // JPA often maps isPublic to public in JSON
-    }
-
-    @Test
-    @DisplayName("isPublic false persists a private event")
-    void testIsPublicFalsePersistsPrivateEvent() throws Exception {
-        EventCreateRequest request = EventCreateRequest.builder()
-                .title("Private Event")
-                .description("Description")
-                .location("Location")
-                .eventDate(LocalDateTime.now().plusDays(1))
-                .isPublic(false)
-                .build();
-
-        mockMvc.perform(post("/api/events/create")
-                        .with(user("admin@example.com").authorities(() -> "ADMIN"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.public").value(false));
+                .andExpect(status().isConflict());
     }
 }

--- a/src/test/java/com/sandeep/eventrabackend/controller/GetEventByIdTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/GetEventByIdTests.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
 import com.sandeep.eventrabackend.repository.EventRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,11 +29,15 @@ public class GetEventByIdTests {
     @Autowired
     private EventRepository eventRepository;
 
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
     private Long publicEventId;
     private Long privateEventId;
 
     @BeforeEach
     void setUp() {
+        eventRegistrationRepository.deleteAll();
         eventRepository.deleteAll();
 
         Event publicEvent = new Event();


### PR DESCRIPTION
## Related Issue
Fixes SandeepVashishtha/Eventra#2099

## Description
Implemented the backend **Update Event API** for modifying existing event details.

### Changes Made
- Added `PUT /api/events/{id}`
- Added `EventUpdateRequest`
- Added `EventService.updateEvent(...)`
- Restricted updates to `ORGANIZER` and `ADMIN`
- Preserved `registeredCount` during updates
- Rejected invalid capacity reductions
- Added `EventUpdateTests.java`

## Verification
- Manual verification completed for create → update → fetch flow
- Verified private events remain retrievable by direct ID
- Full backend tests passed

<details>
<summary><strong>Verification Evidence</strong></summary>

<br>

### Screenshot 1 — Create Event Successfully
<p align="center">
  <img src="https://github.com/user-attachments/assets/476a91de-d225-456d-ab49-0ac1da4f053d" width="800" />
</p>

### Screenshot 2 — Update Event Successfully
<p align="center">
  <img src="https://github.com/user-attachments/assets/179f20af-5dd8-4443-b98f-097d92bd8808" width="800" />
</p>

### Screenshot 3 — Update Event Back to Private
<p align="center">
  <img src="https://github.com/user-attachments/assets/40cfd4bc-e815-459b-8330-17d2edb30c45" width="800" />
</p>

### Screenshot 4 — Fetch Updated Private Event by ID
<p align="center">
  <img src="https://github.com/user-attachments/assets/a86fd535-7a84-4735-8b0c-f76faf2b3184" width="800" />
</p>

### Screenshot 6 — Final Build / Test Check
<p align="center">
  <img src="https://github.com/user-attachments/assets/9e25f496-21d5-4e11-8a90-d820b7664c2e" width="800" />
</p>

</details>
