### PR TITLE
feat: Implement delete event API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -235,27 +235,21 @@ public class EventController {
                     responseCode = "401",
                     description = "Unauthorized - JWT token missing or invalid",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = ErrorResponse.class
-                            )
+                            schema = @Schema(implementation = ErrorResponse.class)
                     )
             ),
             @ApiResponse(
                     responseCode = "404",
                     description = "Event or user not found",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = ErrorResponse.class
-                            )
+                            schema = @Schema(implementation = ErrorResponse.class)
                     )
             ),
             @ApiResponse(
                     responseCode = "409",
                     description = "Event is already full or user already registered",
                     content = @Content(
-                            schema = @Schema(
-                                    implementation = ErrorResponse.class
-                            )
+                            schema = @Schema(implementation = ErrorResponse.class)
                     )
             )
     })
@@ -270,5 +264,49 @@ public class EventController {
                 eventService.registerUserForEvent(id, userEmail);
 
         return ResponseEntity.ok(response);
+    }
+
+    // ── Issue #2100 — DELETE /api/events/{id} ───────────────────────────────
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Delete an event",
+            description = "Allows an ADMIN or SUPER_ADMIN to delete an event.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Event deleted successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User does not have ADMIN or SUPER_ADMIN role",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Event not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<Void> deleteEvent(
+            @Parameter(description = "ID of the event to delete")
+            @PathVariable Long id) {
+
+        eventService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sandeep/eventrabackend/model/Role.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Role.java
@@ -3,5 +3,6 @@ package com.sandeep.eventrabackend.model;
 public enum Role {
     CLIENT,
     ORGANIZER,
-    ADMIN
+    ADMIN,
+    SUPER_ADMIN
 }

--- a/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/EventRegistrationRepository.java
@@ -12,4 +12,6 @@ public interface EventRegistrationRepository extends JpaRepository<EventRegistra
     boolean existsByEvent_IdAndUser_Email(Long eventId, String userEmail);
 
     List<EventRegistration> findByUser_EmailOrderByRegisteredAtDesc(String userEmail);
+
+    void deleteByEventId(Long eventId);
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -188,6 +188,22 @@ public class EventService {
     }
 
     /**
+     * Deletes an existing event and its registrations.
+     *
+     * @param id ID of the event to delete
+     * @throws EventNotFoundException if the event does not exist
+     */
+    @Transactional
+    public void deleteEvent(Long id) {
+        Event event = eventRepository.findById(id)
+                .orElseThrow(() ->
+                        new EventNotFoundException("Event not found with id: " + id));
+
+        eventRegistrationRepository.deleteByEventId(id);
+        eventRepository.delete(event);
+    }
+
+    /**
      * Registers the authenticated user for an event.
      *
      * <p>Business rules enforced:

--- a/src/test/java/com/sandeep/eventrabackend/controller/EventDeleteTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/EventDeleteTests.java
@@ -1,0 +1,167 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class EventDeleteTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Event existingEvent;
+
+    @BeforeEach
+    void setUp() {
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Create users
+        userRepository.save(User.builder()
+                .firstName("SuperAdmin")
+                .lastName("User")
+                .email("superadmin@example.com")
+                .username("superadmin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.SUPER_ADMIN)
+                .build());
+
+        userRepository.save(User.builder()
+                .firstName("Admin")
+                .lastName("User")
+                .email("admin@example.com")
+                .username("admin")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ADMIN)
+                .build());
+
+        userRepository.save(User.builder()
+                .firstName("Organizer")
+                .lastName("User")
+                .email("organizer@example.com")
+                .username("organizer")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.ORGANIZER)
+                .build());
+
+        userRepository.save(User.builder()
+                .firstName("Client")
+                .lastName("User")
+                .email("client@example.com")
+                .username("client")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build());
+
+        // Create an existing event
+        Event event = new Event();
+        event.setTitle("Event to delete");
+        event.setDescription("Description");
+        event.setLocation("Location");
+        event.setEventDate(LocalDateTime.now().plusDays(5));
+        event.setCapacity(100);
+        event.setPublic(true);
+        existingEvent = eventRepository.save(event);
+    }
+
+    @Test
+    @DisplayName("ADMIN can delete event successfully")
+    void deleteEvent_AsAdmin_Success() throws Exception {
+        mockMvc.perform(delete("/api/events/" + existingEvent.getId())
+                        .with(user("admin@example.com").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isNoContent());
+
+        assertFalse(eventRepository.existsById(existingEvent.getId()));
+    }
+
+    @Test
+    @DisplayName("SUPER_ADMIN can delete event successfully")
+    void deleteEvent_AsSuperAdmin_Success() throws Exception {
+        mockMvc.perform(delete("/api/events/" + existingEvent.getId())
+                        .with(user("superadmin@example.com").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("SUPER_ADMIN"))))
+                .andExpect(status().isNoContent());
+
+        assertFalse(eventRepository.existsById(existingEvent.getId()));
+    }
+
+    @Test
+    @DisplayName("Deletion cleans up registrations")
+    void deleteEvent_CleansUpRegistrations() throws Exception {
+        // Create a registration
+        User client = userRepository.findByEmail("client@example.com").orElseThrow();
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(existingEvent);
+        registration.setUser(client);
+        registration.setStatus("CONFIRMED");
+        eventRegistrationRepository.save(registration);
+
+        mockMvc.perform(delete("/api/events/" + existingEvent.getId())
+                        .with(user("admin@example.com").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isNoContent());
+
+        assertFalse(eventRepository.existsById(existingEvent.getId()));
+        assertFalse(eventRegistrationRepository.existsByEvent_IdAndUser_Email(existingEvent.getId(), client.getEmail()));
+    }
+
+    @Test
+    @DisplayName("ORGANIZER cannot delete event")
+    void deleteEvent_AsOrganizer_Forbidden() throws Exception {
+        mockMvc.perform(delete("/api/events/" + existingEvent.getId())
+                        .with(user("organizer@example.com").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("ORGANIZER"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("CLIENT cannot delete event")
+    void deleteEvent_AsClient_Forbidden() throws Exception {
+        mockMvc.perform(delete("/api/events/" + existingEvent.getId())
+                        .with(user("client@example.com").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("CLIENT"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Deleting non-existent event returns 404")
+    void deleteEvent_NonExistent_NotFound() throws Exception {
+        mockMvc.perform(delete("/api/events/999999")
+                        .with(user("admin@example.com").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Event not found with id: 999999"));
+    }
+}


### PR DESCRIPTION
## Related Issue

Fixes SandeepVashishtha/Eventra#2100

## Description

This PR implements the backend API for deleting events by ID.

The new endpoint allows authorized admin users to delete events while enforcing proper role-based access control and missing-event handling.

## Changes Made

- Added `SUPER_ADMIN` to the role enum
- Added `DELETE /api/events/{id}`
- Restricted event deletion to `ADMIN` and `SUPER_ADMIN`
- Added service-layer delete logic using direct event ID lookup
- Ensured related event registrations are deleted before deleting the event
- Preserved existing 404 behavior for missing event IDs
- Added tests for successful deletion, forbidden access, missing events, and registration cleanup

## Verification

- Manually created an event as an `ORGANIZER`
- Verified `ORGANIZER` cannot delete an event and receives `403 Forbidden`
- Promoted user to `ADMIN` and verified event deletion returns `204 No Content`
- Verified deleted event returns `404 Not Found`
- Ran full backend test suite successfully

<details>
<summary><strong>Verification Evidence</strong></summary>

<br>

### Create Event as Organizer

<p align="center">
  <img src="https://github.com/user-attachments/assets/5ab3094e-b69f-41f5-b1a6-1fb533529396" width="650" />
</p>

### Delete Attempt as Organizer — Forbidden

<p align="center">
  <img src="https://github.com/user-attachments/assets/6ab04f5c-5477-47c7-976b-21e7c6ea5849" width="650" />
</p>

### Delete Event as Admin + Verify 404 After Deletion

<p align="center">
  <img src="https://github.com/user-attachments/assets/d357c674-2d05-45b9-b3ab-830be72b1a69" width="650" />
</p>

### Backend Tests Passing

<p align="center">
  <img src="https://github.com/user-attachments/assets/6df31630-c152-44b0-9d24-e27460885e5b" width="650" />
</p>

</details>
