### PR TITLE
feat/fix: Add EventResponse DTO for event APIs

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -4,6 +4,7 @@ import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
 import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
+import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.service.EventService;
@@ -54,7 +55,7 @@ public class EventController {
                     responseCode = "201",
                     description = "Event created successfully",
                     content = @Content(
-                            schema = @Schema(implementation = Event.class)
+                            schema = @Schema(implementation = EventResponse.class)
                     )
             ),
             @ApiResponse(
@@ -79,10 +80,10 @@ public class EventController {
                     )
             )
     })
-    public ResponseEntity<Event> createEvent(
+    public ResponseEntity<EventResponse> createEvent(
             @Valid @RequestBody EventCreateRequest request) {
 
-        Event createdEvent = eventService.createEvent(request);
+        EventResponse createdEvent = eventService.createEvent(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdEvent);
     }
 
@@ -100,7 +101,7 @@ public class EventController {
                     responseCode = "200",
                     description = "Event updated successfully",
                     content = @Content(
-                            schema = @Schema(implementation = Event.class)
+                            schema = @Schema(implementation = EventResponse.class)
                     )
             ),
             @ApiResponse(
@@ -132,12 +133,12 @@ public class EventController {
                     )
             )
     })
-    public ResponseEntity<Event> updateEvent(
+    public ResponseEntity<EventResponse> updateEvent(
             @Parameter(description = "ID of the event to update")
             @PathVariable Long id,
             @Valid @RequestBody EventUpdateRequest request) {
 
-        Event updatedEvent = eventService.updateEvent(id, request);
+        EventResponse updatedEvent = eventService.updateEvent(id, request);
         return ResponseEntity.ok(updatedEvent);
     }
 
@@ -153,7 +154,7 @@ public class EventController {
                     responseCode = "200",
                     description = "Event fetched successfully",
                     content = @Content(
-                            schema = @Schema(implementation = Event.class)
+                            schema = @Schema(implementation = EventResponse.class)
                     )
             ),
             @ApiResponse(
@@ -164,11 +165,11 @@ public class EventController {
                     )
             )
     })
-    public ResponseEntity<Event> getPublicEventById(
+    public ResponseEntity<EventResponse> getPublicEventById(
             @Parameter(description = "ID of the public event")
             @PathVariable Long id) {
 
-        Event event = eventService.getPublicEventById(id);
+        EventResponse event = eventService.getPublicEventById(id);
         return ResponseEntity.ok(event);
     }
 

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/EventResponse.java
@@ -1,0 +1,43 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response payload containing event details")
+public class EventResponse {
+
+    @Schema(description = "Unique ID of the event", example = "1")
+    private Long id;
+
+    @Schema(description = "Event title", example = "Tech Conference 2026")
+    private String title;
+
+    @Schema(description = "Detailed event description", example = "A deep dive into AI and Cloud computing.")
+    private String description;
+
+    @Schema(description = "Physical or virtual location", example = "San Francisco, CA")
+    private String location;
+
+    @Schema(description = "Date and time when the event starts")
+    private LocalDateTime eventDate;
+
+    @Schema(description = "Maximum number of attendees allowed (null for unlimited)", example = "100")
+    private Integer capacity;
+
+    @Schema(description = "Number of confirmed registrations so far.", example = "42")
+    private int registeredCount;
+
+    @JsonProperty("public")
+    @Schema(description = "Whether the event is publicly visible", example = "true")
+    private boolean isPublic;
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -3,6 +3,7 @@ package com.sandeep.eventrabackend.service;
 import com.sandeep.eventrabackend.dto.request.EventCreateRequest;
 import com.sandeep.eventrabackend.dto.request.EventUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.EventAvailabilityResponse;
+import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
 import com.sandeep.eventrabackend.exception.EventFullException;
@@ -106,8 +107,9 @@ public class EventService {
      *
      * @throws EventNotFoundException if the event does not exist
      */
-    public Event getPublicEventById(long id) {
+    public EventResponse getPublicEventById(long id) {
         return eventRepository.findById(id)
+                .map(this::toEventResponse)
                 .orElseThrow(() ->
                         new EventNotFoundException(
                                 "Event not found with id: " + id));
@@ -139,7 +141,7 @@ public class EventService {
      * @return the saved event
      */
     @Transactional
-    public Event createEvent(EventCreateRequest request) {
+    public EventResponse createEvent(EventCreateRequest request) {
         Event event = new Event();
         event.setTitle(request.getTitle());
         event.setDescription(request.getDescription());
@@ -153,7 +155,8 @@ public class EventService {
         // Ensure registeredCount is 0 for new events
         event.setRegisteredCount(0);
 
-        return eventRepository.save(event);
+        Event saved = eventRepository.save(event);
+        return toEventResponse(saved);
     }
 
     /**
@@ -165,7 +168,7 @@ public class EventService {
      * @throws EventNotFoundException if the event does not exist
      */
     @Transactional
-    public Event updateEvent(Long id, EventUpdateRequest request) {
+    public EventResponse updateEvent(Long id, EventUpdateRequest request) {
         Event event = eventRepository.findById(id)
                 .orElseThrow(() ->
                         new EventNotFoundException("Event not found with id: " + id));
@@ -184,7 +187,8 @@ public class EventService {
         event.setCapacity(request.getCapacity());
         event.setPublic(request.getIsPublic() == null || request.getIsPublic());
 
-        return eventRepository.save(event);
+        Event saved = eventRepository.save(event);
+        return toEventResponse(saved);
     }
 
     /**
@@ -324,6 +328,19 @@ public class EventService {
                 .eventDate(event.getEventDate())
                 .registeredAt(registration.getRegisteredAt())
                 .status(registration.getStatus())
+                .build();
+    }
+
+    private EventResponse toEventResponse(Event event) {
+        return EventResponse.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .description(event.getDescription())
+                .location(event.getLocation())
+                .eventDate(event.getEventDate())
+                .capacity(event.getCapacity())
+                .registeredCount(event.getRegisteredCount())
+                .isPublic(event.isPublic())
                 .build();
     }
 }


### PR DESCRIPTION
## Related Issue

Fixes SandeepVashishtha/Eventra#3098

## Description

This PR adds a dedicated `EventResponse` DTO for event API responses instead of returning raw `Event` JPA entities directly.

## Changes Made

* Added `EventResponse` DTO with API-safe event fields
* Updated event create, update, and get-by-id service methods to return `EventResponse`
* Updated event controller response types from raw `Event` to `EventResponse`
* Updated Swagger/OpenAPI schema references for affected endpoints
* Preserved existing JSON field naming using `@JsonProperty("public")`

## Security / API Safety

* Prevents exposing internal JPA fields such as `version`
* Prevents exposing `attendees` and nested `User` objects through event responses
* Keeps event API responses stable and decoupled from the persistence model

## Verification

```bash
./mvnw.cmd clean test
```

Result: `BUILD SUCCESS` — 41 tests passed.

## Type of PR

* [x] Bug fix
* [x] Security improvement
* [x] API cleanup
