### PR TITLE
Add authenticated user profile update endpoint with validation and Swagger documentation

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -16,6 +16,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.sandeep.eventrabackend.dto.request.UpdateUserProfileRequest;
+import com.sandeep.eventrabackend.dto.response.UserProfileResponse;
+import com.sandeep.eventrabackend.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -25,9 +31,79 @@ import java.util.List;
 public class UserController {
 
     private final EventService eventService;
+    private final UserService userService;
 
-    public UserController(EventService eventService) {
+    public UserController(
+            EventService eventService,
+            UserService userService
+    ) {
         this.eventService = eventService;
+        this.userService = userService;
+    }
+
+    @PutMapping("/profile")
+    @Operation(
+            summary = "Update authenticated user profile",
+            description = """
+                Updates editable profile information for the currently authenticated user.
+                
+                Requires a valid JWT token.
+                
+                Editable fields:
+                - firstName
+                - lastName
+                """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Profile updated successfully",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = UserProfileResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Validation error",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ErrorResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ErrorResponse.class
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Authenticated user not found",
+                    content = @Content(
+                            schema = @Schema(
+                                    implementation = ErrorResponse.class
+                            )
+                    )
+            )
+    })
+    public ResponseEntity<UserProfileResponse> updateProfile(
+            @Valid @RequestBody UpdateUserProfileRequest request,
+            Authentication authentication
+    ) {
+
+        return ResponseEntity.ok(
+                userService.updateProfile(
+                        authentication.getName(),
+                        request
+                )
+        );
     }
 
     @GetMapping("/my-events")

--- a/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -98,9 +98,13 @@ public class UserController {
             Authentication authentication
     ) {
 
+        // Extract authenticated user's email from JWT security context
+        String authenticatedEmail = authentication.getName();
+
+        // Delegate profile update logic to service layer
         return ResponseEntity.ok(
                 userService.updateProfile(
-                        authentication.getName(),
+                        authenticatedEmail,
                         request
                 )
         );

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/UpdateUserProfileRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/UpdateUserProfileRequest.java
@@ -1,0 +1,21 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Schema(description = "Request payload for updating authenticated user profile")
+public class UpdateUserProfileRequest {
+
+    @NotBlank(message = "First name is required")
+    @Size(min = 2, max = 50, message = "First name must be between 2 and 50 characters")
+    @Schema(description = "User first name", example = "John")
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    @Size(min = 2, max = 50, message = "Last name must be between 2 and 50 characters")
+    @Schema(description = "User last name", example = "Doe")
+    private String lastName;
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/UserProfileResponse.java
@@ -1,0 +1,30 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.sandeep.eventrabackend.model.Role;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@Schema(description = "Authenticated user profile response")
+public class UserProfileResponse {
+
+    @Schema(description = "User ID", example = "1")
+    private Long id;
+
+    @Schema(description = "User first name", example = "John")
+    private String firstName;
+
+    @Schema(description = "User last name", example = "Doe")
+    private String lastName;
+
+    @Schema(description = "Unique username", example = "john_doe")
+    private String username;
+
+    @Schema(description = "User email address", example = "john@example.com")
+    private String email;
+
+    @Schema(description = "User role", example = "CLIENT")
+    private Role role;
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/UserService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/UserService.java
@@ -1,0 +1,50 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.request.UpdateUserProfileRequest;
+import com.sandeep.eventrabackend.dto.response.UserProfileResponse;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public UserProfileResponse updateProfile(
+            String authenticatedEmail,
+            UpdateUserProfileRequest request
+    ) {
+
+        User user = userRepository.findByEmail(authenticatedEmail)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException(
+                                "Authenticated user not found"));
+
+        user.setFirstName(request.getFirstName());
+        user.setLastName(request.getLastName());
+
+        User updatedUser = userRepository.save(user);
+
+        return mapToProfileResponse(updatedUser);
+    }
+
+    private UserProfileResponse mapToProfileResponse(User user) {
+
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/UserService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/UserService.java
@@ -17,22 +17,28 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
+
+    // Uses authenticated email extracted from Spring Security JWT context
+    // to identify and update the currently logged-in user
     @Transactional
     public UserProfileResponse updateProfile(
             String authenticatedEmail,
             UpdateUserProfileRequest request
     ) {
 
+        // Fetch currently authenticated user from database
         User user = userRepository.findByEmail(authenticatedEmail)
                 .orElseThrow(() ->
                         new UsernameNotFoundException(
                                 "Authenticated user not found"));
 
+        // Update editable profile fields
         user.setFirstName(request.getFirstName());
         user.setLastName(request.getLastName());
 
         User updatedUser = userRepository.save(user);
 
+        // Return updated user profile response
         return mapToProfileResponse(updatedUser);
     }
 


### PR DESCRIPTION
Added a new authenticated profile update endpoint for logged-in users.

Implemented:

* `PUT /api/users/profile`
* Request validation using DTOs
* Structured profile response DTO
* Authenticated user lookup using Spring Security context
* User profile update service layer
* Swagger/OpenAPI documentation
* Proper error handling integration using existing global exception handling

## Features

### Added Request DTO

* `UpdateUserProfileRequest`
* Validation for:

  * `firstName`
  * `lastName`

### Added Response DTO

* `UserProfileResponse`

### Added Service Layer

* `UserService`
* Handles authenticated user lookup and profile updates

### Added Endpoint

```http
PUT /api/users/profile
```

### Security

* Requires valid JWT authentication
* Returns `401 Unauthorized` for missing/invalid tokens

### Validation

* Returns validation errors for invalid request fields

## Testing

Verified:

* Successful profile update
* JWT-protected access
* Validation failure responses
* Swagger endpoint visibility
* Unauthorized access handling
