### PR TITLE
feat: add authenticated user profile API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -2,6 +2,9 @@ package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
+import com.sandeep.eventrabackend.dto.response.UserProfileResponse;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.service.EventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -13,6 +16,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,9 +29,51 @@ import java.util.List;
 public class UserController {
 
     private final EventService eventService;
+    private final UserRepository userRepository;
 
-    public UserController(EventService eventService) {
+    public UserController(EventService eventService, UserRepository userRepository) {
         this.eventService = eventService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/profile")
+    @Operation(
+            summary = "Get authenticated user profile",
+            description = "Returns the basic profile details for the currently authenticated JWT user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User profile fetched successfully",
+                    content = @Content(schema = @Schema(implementation = UserProfileResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<UserProfileResponse> getUserProfile(Authentication authentication) {
+        String email = authentication.getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        UserProfileResponse response = UserProfileResponse.builder()
+                .id(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .role(user.getRole() != null ? user.getRole().name() : null)
+                .build();
+
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/my-events")

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/UserProfileResponse.java
@@ -1,0 +1,31 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "User profile details response")
+public class UserProfileResponse {
+
+    @Schema(description = "User ID")
+    private Long id;
+
+    @Schema(description = "First name")
+    private String firstName;
+
+    @Schema(description = "Last name")
+    private String lastName;
+
+    @Schema(description = "Username")
+    private String username;
+
+    @Schema(description = "Email address")
+    private String email;
+
+    @Schema(description = "Role assigned to the user")
+    private String role;
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/UserProfileTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/UserProfileTests.java
@@ -1,0 +1,79 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class UserProfileTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+
+        User u = User.builder()
+                .firstName("John")
+                .lastName("Doe")
+                .email("john@example.com")
+                .username("johndoe")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(u);
+    }
+
+    @Test
+    @DisplayName("GET /api/users/profile - Success")
+    void testGetUserProfile_Success() throws Exception {
+        mockMvc.perform(get("/api/users/profile")
+                        .with(user("john@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("John"))
+                .andExpect(jsonPath("$.lastName").value("Doe"))
+                .andExpect(jsonPath("$.email").value("john@example.com"))
+                .andExpect(jsonPath("$.username").value("johndoe"))
+                .andExpect(jsonPath("$.role").value("CLIENT"))
+                .andExpect(jsonPath("$.id").exists());
+    }
+
+    @Test
+    @DisplayName("GET /api/users/profile - Unauthorized")
+    void testGetUserProfile_Unauthorized() throws Exception {
+        mockMvc.perform(get("/api/users/profile"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /api/users/profile - User Not Found")
+    void testGetUserProfile_NotFound() throws Exception {
+        mockMvc.perform(get("/api/users/profile")
+                        .with(user("missing@example.com")))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("User not found with email: missing@example.com"));
+    }
+}


### PR DESCRIPTION
## Related Issue

Fixes SandeepVashishtha/Eventra#3163

## Description

This PR implements the authenticated user profile API in the Eventra Spring Boot backend.

The new endpoint allows a logged-in user to fetch their own basic profile details using the existing JWT authentication flow.

## Changes Made

* Added `GET /api/users/profile`
* Added `UserProfileResponse` DTO
* Fetches the authenticated user using `authentication.getName()`
* Uses the existing `UserRepository.findByEmail(...)` lookup
* Returns basic profile details:

  * `id`
  * `firstName`
  * `lastName`
  * `username`
  * `email`
  * `role`
* Added Swagger/OpenAPI documentation for the new endpoint
* Added tests for:

  * successful authenticated profile retrieval
  * unauthenticated access rejection
  * authenticated user not found handling

## Notes

This PR only implements the profile retrieval endpoint required for #3163.

It does not implement `PUT /api/users/profile`, which is tracked separately in #3164.

## Verification

* Ran `.\mvnw.cmd test`
* Manually verified signup and authenticated profile retrieval using PowerShell

<details>
<summary><strong>Screenshot 1 — User Signup</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/de3e68f2-de23-4b6a-80b2-86fdf8f602f8" width="600" />
</p>

</details>

<details>
<summary><strong>Screenshot 2 — Authenticated User Profile Retrieval</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/d702fd83-e1bd-42fa-b891-c5aedb3afa4d" width="600" />
</p>

</details>
