### PR TITLE
feat: add user profile update API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.request.UserProfileUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.MyRegisteredEventResponse;
 import com.sandeep.eventrabackend.dto.response.UserProfileResponse;
+import com.sandeep.eventrabackend.exception.UserAlreadyExistsException;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.service.EventService;
@@ -14,12 +16,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -64,16 +65,62 @@ public class UserController {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
 
-        UserProfileResponse response = UserProfileResponse.builder()
-                .id(user.getId())
-                .firstName(user.getFirstName())
-                .lastName(user.getLastName())
-                .username(user.getUsername())
-                .email(user.getEmail())
-                .role(user.getRole() != null ? user.getRole().name() : null)
-                .build();
+        return ResponseEntity.ok(mapToUserProfileResponse(user));
+    }
 
-        return ResponseEntity.ok(response);
+    @PutMapping("/profile")
+    @Operation(
+            summary = "Update authenticated user profile",
+            description = "Updates the first name, last name, and username for the currently authenticated JWT user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User profile updated successfully",
+                    content = @Content(schema = @Schema(implementation = UserProfileResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Validation error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "Username already exists",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<UserProfileResponse> updateUserProfile(
+            @Valid @RequestBody UserProfileUpdateRequest request,
+            Authentication authentication) {
+        
+        String email = authentication.getName();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+
+        // Check if username is being changed and if new username already exists
+        if (!user.getUsername().equals(request.getUsername()) && 
+                userRepository.existsByUsername(request.getUsername())) {
+            throw new UserAlreadyExistsException("Username already exists: " + request.getUsername());
+        }
+
+        user.setFirstName(request.getFirstName());
+        user.setLastName(request.getLastName());
+        user.setUsername(request.getUsername());
+
+        User updatedUser = userRepository.save(user);
+        return ResponseEntity.ok(mapToUserProfileResponse(updatedUser));
     }
 
     @GetMapping("/my-events")
@@ -98,5 +145,16 @@ public class UserController {
             Authentication authentication) {
 
         return ResponseEntity.ok(eventService.getRegisteredEventsForUser(authentication.getName()));
+    }
+
+    private UserProfileResponse mapToUserProfileResponse(User user) {
+        return UserProfileResponse.builder()
+                .id(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .role(user.getRole() != null ? user.getRole().name() : null)
+                .build();
     }
 }

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,32 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "User profile update request payload")
+public class UserProfileUpdateRequest {
+
+    @NotBlank(message = "First name is required")
+    @Size(min = 2, max = 50, message = "First name must be between 2 and 50 characters")
+    @Schema(description = "User's first name", example = "John")
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    @Size(min = 2, max = 50, message = "Last name must be between 2 and 50 characters")
+    @Schema(description = "User's last name", example = "Doe")
+    private String lastName;
+
+    @NotBlank(message = "Username is required")
+    @Size(min = 3, max = 50, message = "Username must be between 3 and 50 characters")
+    @Schema(description = "User's unique username", example = "johndoe123")
+    private String username;
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/UserProfileUpdateTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/UserProfileUpdateTests.java
@@ -1,0 +1,178 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.UserProfileUpdateRequest;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class UserProfileUpdateTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+
+        User u1 = User.builder()
+                .firstName("John")
+                .lastName("Doe")
+                .email("john@example.com")
+                .username("johndoe")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(u1);
+
+        User u2 = User.builder()
+                .firstName("Jane")
+                .lastName("Smith")
+                .email("jane@example.com")
+                .username("janesmith")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(u2);
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - Success")
+    void testUpdateUserProfile_Success() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("Johnny")
+                .lastName("Updated")
+                .username("johnny_up")
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Johnny"))
+                .andExpect(jsonPath("$.lastName").value("Updated"))
+                .andExpect(jsonPath("$.username").value("johnny_up"))
+                .andExpect(jsonPath("$.email").value("john@example.com"))
+                .andExpect(jsonPath("$.role").value("CLIENT"));
+
+        User updatedUser = userRepository.findByEmail("john@example.com").orElseThrow();
+        assertEquals("Johnny", updatedUser.getFirstName());
+        assertEquals("Updated", updatedUser.getLastName());
+        assertEquals("johnny_up", updatedUser.getUsername());
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - Unauthorized")
+    void testUpdateUserProfile_Unauthorized() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("Johnny")
+                .lastName("Updated")
+                .username("johnny_up")
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - User Not Found")
+    void testUpdateUserProfile_NotFound() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("Johnny")
+                .lastName("Updated")
+                .username("johnny_up")
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("missing@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("User not found with email: missing@example.com"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - Duplicate Username")
+    void testUpdateUserProfile_DuplicateUsername() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("John")
+                .lastName("Doe")
+                .username("janesmith") // already used by jane@example.com
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Username already exists: janesmith"));
+
+        User user = userRepository.findByEmail("john@example.com").orElseThrow();
+        assertEquals("johndoe", user.getUsername());
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - Same Username (No Conflict)")
+    void testUpdateUserProfile_SameUsername() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("Johnny")
+                .lastName("Doe")
+                .username("johndoe") // same as current
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("johndoe"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/users/profile - Validation Failure")
+    void testUpdateUserProfile_ValidationFailure() throws Exception {
+        UserProfileUpdateRequest request = UserProfileUpdateRequest.builder()
+                .firstName("") // Blank
+                .lastName("Doe")
+                .username("j") // Too short
+                .build();
+
+        mockMvc.perform(put("/api/users/profile")
+                        .with(user("john@example.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Validation Error"));
+    }
+}


### PR DESCRIPTION
## Related Issue

Fixes SandeepVashishtha/Eventra#3164

## Description

Implemented the authenticated user profile update API in the backend.

## Changes Made

- Added `PUT /api/users/profile`
- Added `UserProfileUpdateRequest` DTO
- Allowed authenticated users to update:
  - first name
  - last name
  - username
- Reused `UserProfileResponse` for the response payload
- Added duplicate username handling with `409 Conflict`
- Added Swagger/OpenAPI documentation for the new endpoint
- Added tests for:
  - successful profile update
  - unauthenticated access rejection
  - authenticated user not found handling
  - duplicate username conflict
  - validation failures
  - unchanged username update behavior

## Notes

Email updates are intentionally excluded because the authenticated JWT subject is based on the user's email. Password, role, and ID updates are also not allowed through this endpoint.

## Verification

- Ran full backend test suite
- Result: 50 tests passed, 0 failures, 0 errors

```bash
./mvnw.cmd test
```

<details>
<summary><strong>Manual Verification Evidence</strong></summary>

<br>

### Successful Profile Update

<p align="center">
  <img src="https://github.com/user-attachments/assets/5f0f6646-a875-4dd6-87ba-1ec359016714" width="650" />
</p>

### Duplicate Username Conflict

<p align="center">
  <img src="https://github.com/user-attachments/assets/a47cfc86-5063-4a88-a4d5-eb880a5763a4" width="650" />
</p>

</details>


