### PR TITLE
Fix capacity validation to reject zero values

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/dto/request/EventCreateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/EventCreateRequest.java
@@ -1,10 +1,7 @@
 package com.sandeep.eventrabackend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -36,7 +33,7 @@ public class EventCreateRequest {
     @Schema(description = "Date and time when the event starts")
     private LocalDateTime eventDate;
 
-    @Positive(message = "Capacity must be positive")
+    @Min(value = 1, message = "Capacity must be at least 1")
     @Schema(description = "Maximum number of attendees allowed (null for unlimited)", example = "100")
     private Integer capacity;
 

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/EventUpdateRequest.java
@@ -1,10 +1,7 @@
 package com.sandeep.eventrabackend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -36,7 +33,7 @@ public class EventUpdateRequest {
     @Schema(description = "Date and time when the event starts")
     private LocalDateTime eventDate;
 
-    @Positive(message = "Capacity must be positive")
+    @Min(value = 1, message = "Capacity must be at least 1")
     @Schema(description = "Maximum number of attendees allowed (null for unlimited)", example = "150")
     private Integer capacity;
 


### PR DESCRIPTION
Updated event capacity validation to reject zero values during event creation and update.

Previously, the `@Positive` annotation allowed `0` as a valid capacity, which could result in events that cannot accept registrations.

This PR replaces `@Positive` with `@Min(1)` to ensure event capacity is always at least 1.

## Changes Made

### Updated Validation

* Replaced:

```java
@Positive
```

with:

```java
@Min(1)
```

### Updated Files

* `EventCreateRequest.java`
* `EventUpdateRequest.java`

## Result

Now:

* Negative capacities are rejected
* Zero capacity is rejected
* Only values greater than or equal to 1 are accepted

This ensures events always have valid registration capacity.
