### PR TITLE
feat: add JWT logout API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -110,6 +110,7 @@ public CorsConfigurationSource corsConfigurationSource() {
                 // Stateless sessions — JWT handles auth
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/logout").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers(
                                 "/actuator",

--- a/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -123,4 +123,27 @@ public ResponseEntity<AuthResponse> googleLogin(
 
     return ResponseEntity.ok(response);
 }
+
+    @PostMapping("/logout")
+    @Operation(
+            summary = "Logout user and invalidate token",
+            description = """
+                    Blacklists the provided JWT token so it cannot be used again until it expires.
+                    
+                    Requires `Authorization: Bearer <token>` header.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Logged out successfully"),
+            @ApiResponse(responseCode = "401", description = "Missing or invalid token",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> logout(@RequestHeader("Authorization") String bearerToken) {
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            authService.logout(token);
+            return ResponseEntity.ok("Logged out successfully");
+        }
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token format");
+    }
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -9,6 +9,7 @@ import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
 import com.sandeep.eventrabackend.repository.UserRepository;
 import com.sandeep.eventrabackend.security.JwtTokenProvider;
+import com.sandeep.eventrabackend.security.TokenBlacklistService;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,18 +28,21 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleAuthService googleAuthService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public AuthService(UserRepository userRepository,
                    PasswordEncoder passwordEncoder,
                    AuthenticationManager authenticationManager,
                    JwtTokenProvider jwtTokenProvider,
-                   GoogleAuthService googleAuthService) {
+                   GoogleAuthService googleAuthService,
+                   TokenBlacklistService tokenBlacklistService) {
 
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
     this.authenticationManager = authenticationManager;
     this.jwtTokenProvider = jwtTokenProvider;
     this.googleAuthService = googleAuthService;
+    this.tokenBlacklistService = tokenBlacklistService;
 }
 
     @Transactional
@@ -157,6 +161,11 @@ if (lastName == null || lastName.isBlank()) {
         );
     }
 }
+
+    public void logout(String token) {
+        java.util.Date expiration = jwtTokenProvider.getExpirationDateFromToken(token);
+        tokenBlacklistService.addToBlacklist(token, expiration);
+    }
 
     // ─── helpers ────────────────────────────────────────────────────────────────
 

--- a/src/test/java/com/sandeep/eventrabackend/controller/AuthLogoutTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/AuthLogoutTests.java
@@ -1,0 +1,110 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.LoginRequest;
+import com.sandeep.eventrabackend.dto.response.AuthResponse;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AuthLogoutTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String jwtToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        userRepository.deleteAll();
+
+        // Create a test user
+        userRepository.save(User.builder()
+                .firstName("Test")
+                .lastName("User")
+                .email("test@example.com")
+                .username("testuser")
+                .password(passwordEncoder.encode("password123"))
+                .role(Role.CLIENT)
+                .build());
+
+        // Login to get a token
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setUsernameOrEmail("testuser");
+        loginRequest.setPassword("password123");
+
+        MvcResult result = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseString = result.getResponse().getContentAsString();
+        AuthResponse authResponse = objectMapper.readValue(responseString, AuthResponse.class);
+        jwtToken = authResponse.getToken();
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/logout with valid token returns 200")
+    void testLogoutSuccess() throws Exception {
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + jwtToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Using token after logout returns 401")
+    void testTokenInvalidAfterLogout() throws Exception {
+        // 1. Logout
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "Bearer " + jwtToken))
+                .andExpect(status().isOk());
+
+        // 2. Try to access protected endpoint
+        mockMvc.perform(get("/api/users/profile")
+                        .header("Authorization", "Bearer " + jwtToken))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/logout without token returns 401")
+    void testLogoutWithoutToken() throws Exception {
+        mockMvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/auth/logout with malformed token returns 401")
+    void testLogoutWithMalformedToken() throws Exception {
+        mockMvc.perform(post("/api/auth/logout")
+                        .header("Authorization", "InvalidFormat " + jwtToken))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Description

This PR implements backend support for JWT logout by adding `POST /api/auth/logout`.

The endpoint invalidates the currently authenticated bearer token by adding it to the existing server-side token blacklist. Once logged out, the same JWT can no longer be used to access protected APIs.

## Changes Made

* Added `POST /api/auth/logout`
* Added logout handling in `AuthService`
* Reused the existing `TokenBlacklistService` to blacklist JWTs until expiry
* Ensured `/api/auth/logout` requires authentication
* Confirmed blacklisted tokens are rejected by the JWT authentication filter
* Added Swagger/OpenAPI documentation for the logout endpoint
* Added controller tests for:

  * successful logout with a valid token
  * rejected access after logout using the same token
  * missing token handling
  * malformed token handling

## Verification

* Ran the backend test suite successfully:

```bash
./mvnw test -Dtest=*Tests
```

Result:

```text
Tests run: 52, Failures: 0, Errors: 0, Skipped: 0
```

<details>
<summary><strong>Manual Verification Evidence</strong></summary>

<br>

### JWT Logout Flow

Verified that a valid JWT can access a protected endpoint before logout, logout succeeds, and the same JWT is rejected afterward.

<p align="center">
  <img src="https://github.com/user-attachments/assets/cc055641-5d6d-4a42-ad0e-0716da75ae38" width="700" />
</p>

</details>

## Notes

No frontend issue is linked because the maintainer asked to proceed directly with the backend PR.
This PR only implements logout support and does not modify password reset, event APIs, or role handling.
