### PR TITLE
feat: add project categories API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -122,6 +122,8 @@ public CorsConfigurationSource corsConfigurationSource() {
                         // Anyone can view an event or check its availability;
                         // only authenticated users can register (POST).
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/events/**").permitAll()
+                        // ── Public: Project categories endpoint ──────────────
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
                         // ── Public: Swagger / OpenAPI ────────────────────
                         .requestMatchers(
                                 "/swagger-ui.html",

--- a/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -1,0 +1,50 @@
+package com.sandeep.eventrabackend.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/projects")
+@Tag(name = "Projects", description = "Endpoints for managing and interacting with projects")
+public class ProjectController {
+
+    private static final List<String> CATEGORIES = List.of(
+            "Mobile Development",
+            "Web Development",
+            "Developer Tools",
+            "Machine Learning",
+            "DevOps",
+            "Design",
+            "IoT",
+            "Blockchain"
+    );
+
+    @GetMapping("/categories")
+    @Operation(
+            summary = "Get all project categories",
+            description = "Returns a list of available categories for projects."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Categories fetched successfully",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = String.class))
+                    )
+            )
+    })
+    public ResponseEntity<List<String>> getCategories() {
+        return ResponseEntity.ok(CATEGORIES);
+    }
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -1,0 +1,42 @@
+package com.sandeep.eventrabackend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class ProjectControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void testGetCategories_PublicAccess_Returns200() throws Exception {
+        mockMvc.perform(get("/api/projects/categories")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(8)))
+                .andExpect(jsonPath("$", hasItems(
+                        "Mobile Development",
+                        "Web Development",
+                        "Developer Tools",
+                        "Machine Learning",
+                        "DevOps",
+                        "Design",
+                        "IoT",
+                        "Blockchain"
+                )));
+    }
+}


### PR DESCRIPTION
## Description

Adds the first backend endpoint for the Projects module by implementing a public API to retrieve supported project categories.

This starts the backend Projects API surface required by the frontend API requirements.

## Changes Made

* Added `GET /api/projects/categories`
* Created `ProjectController` with `/api/projects` base mapping
* Returned a static list of supported project categories
* Added Swagger/OpenAPI documentation for the new endpoint
* Updated security configuration to allow public unauthenticated access only for `GET /api/projects/categories`
* Added controller tests to verify public access and response payload

## API Added

### `GET /api/projects/categories`

Returns the supported project categories:

```json
[
  "Mobile Development",
  "Web Development",
  "Developer Tools",
  "Machine Learning",
  "DevOps",
  "Design",
  "IoT",
  "Blockchain"
]
```

## Verification

* Ran `./mvnw test`
* Verified all tests pass successfully
* Manually verified `GET /api/projects/categories` returns `200 OK` without JWT authentication

<details>
<summary><strong>Verification Evidence</strong></summary>

<br>

### Manual Verification

Verified that the public project categories endpoint returns `200 OK` without requiring JWT authentication.

<p align="center">
  <img src="https://github.com/user-attachments/assets/afe5413e-07bd-45b9-a27e-6076e966d199" width="700" />
</p>

### Test Suite

Confirmed the backend test suite passes successfully.

<p align="center">
  <img src="https://github.com/user-attachments/assets/cd74fcdb-7536-4fc1-b54e-f152652a5de2" width="700" />
</p>

</details>
