### PR TITLE
feat: add projects list API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -123,6 +123,8 @@ public CorsConfigurationSource corsConfigurationSource() {
                         // Anyone can view an event or check its availability;
                         // only authenticated users can register (POST).
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/events/**").permitAll()
+                        // ── Public: Projects endpoint ────────────────────────
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects").permitAll()
                         // ── Public: Project categories endpoint ──────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
                         // ── Public: Swagger / OpenAPI ────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -1,5 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.response.ProjectResponse;
+import com.sandeep.eventrabackend.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -19,6 +21,12 @@ import java.util.List;
 @Tag(name = "Projects", description = "Endpoints for managing and interacting with projects")
 public class ProjectController {
 
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
     private static final List<String> CATEGORIES = List.of(
             "Mobile Development",
             "Web Development",
@@ -29,6 +37,24 @@ public class ProjectController {
             "IoT",
             "Blockchain"
     );
+
+    @GetMapping
+    @Operation(
+            summary = "Get all projects",
+            description = "Returns a list of all available projects."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Projects fetched successfully",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = ProjectResponse.class))
+                    )
+            )
+    })
+    public ResponseEntity<List<ProjectResponse>> getAllProjects() {
+        return ResponseEntity.ok(projectService.getAllProjects());
+    }
 
     @GetMapping("/categories")
     @Operation(

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/ProjectResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/ProjectResponse.java
@@ -1,0 +1,36 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response payload containing project details")
+public class ProjectResponse {
+
+    @Schema(description = "Unique ID of the project", example = "1")
+    private Long id;
+
+    @Schema(description = "Project title", example = "E-commerce Platform")
+    private String title;
+
+    @Schema(description = "Detailed project description", example = "A full-stack e-commerce solution.")
+    private String description;
+
+    @Schema(description = "Project category", example = "Web Development")
+    private String category;
+
+    @Schema(description = "URL to the project's thumbnail image", example = "https://example.com/thumb.png")
+    private String thumbnailUrl;
+
+    @Schema(description = "URL to the project's GitHub repository", example = "https://github.com/user/repo")
+    private String githubUrl;
+
+    @Schema(description = "Number of upvotes received", example = "15")
+    private int upvotes;
+}

--- a/src/main/java/com/sandeep/eventrabackend/model/Project.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Project.java
@@ -1,0 +1,36 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "projects")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(nullable = false)
+    private String category;
+
+    private String thumbnailUrl;
+
+    private String githubUrl;
+
+    @Builder.Default
+    private int upvotes = 0;
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java
@@ -1,0 +1,9 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -1,0 +1,39 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.response.ProjectResponse;
+import com.sandeep.eventrabackend.model.Project;
+import com.sandeep.eventrabackend.repository.ProjectRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+
+    public ProjectService(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectResponse> getAllProjects() {
+        return projectRepository.findAll().stream()
+                .map(this::toProjectResponse)
+                .collect(Collectors.toList());
+    }
+
+    private ProjectResponse toProjectResponse(Project project) {
+        return ProjectResponse.builder()
+                .id(project.getId())
+                .title(project.getTitle())
+                .description(project.getDescription())
+                .category(project.getCategory())
+                .thumbnailUrl(project.getThumbnailUrl())
+                .githubUrl(project.getGithubUrl())
+                .upvotes(project.getUpvotes())
+                .build();
+    }
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -1,5 +1,8 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.model.Project;
+import com.sandeep.eventrabackend.repository.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -7,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
@@ -20,6 +25,48 @@ public class ProjectControllerTests {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @BeforeEach
+    void setUp() {
+        projectRepository.deleteAll();
+    }
+
+    @Test
+    void testGetAllProjects_EmptyList_Returns200() throws Exception {
+        mockMvc.perform(get("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void testGetAllProjects_PublicAccess_ReturnsProjects() throws Exception {
+        Project project = Project.builder()
+                .title("Test Project")
+                .description("Test Description")
+                .category("Web Development")
+                .thumbnailUrl("http://example.com/thumb.png")
+                .githubUrl("http://github.com/test/repo")
+                .upvotes(10)
+                .build();
+        projectRepository.save(project);
+
+        mockMvc.perform(get("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title").value("Test Project"))
+                .andExpect(jsonPath("$[0].description").value("Test Description"))
+                .andExpect(jsonPath("$[0].category").value("Web Development"))
+                .andExpect(jsonPath("$[0].thumbnailUrl").value("http://example.com/thumb.png"))
+                .andExpect(jsonPath("$[0].githubUrl").value("http://github.com/test/repo"))
+                .andExpect(jsonPath("$[0].upvotes").value(10));
+    }
 
     @Test
     void testGetCategories_PublicAccess_Returns200() throws Exception {


### PR DESCRIPTION
## Description

Adds the backend Projects list endpoint for the Projects gallery/module.

## Changes Made

* Added `GET /api/projects`
* Added `Project` entity
* Added `ProjectRepository`
* Added `ProjectService`
* Added `ProjectResponse` DTO
* Updated `ProjectController` to return the projects list
* Updated security config to allow public access only for `GET /api/projects`
* Added controller tests for empty and populated project list responses

## Verification

* Ran `./mvnw test -Dtest=ProjectControllerTests`
* Manually verified `GET /api/projects` returns `200 OK` without authentication
* Manually verified the endpoint returns project fields:

  * `id`
  * `title`
  * `description`
  * `category`
  * `thumbnailUrl`
  * `githubUrl`
  * `upvotes`

<details>
<summary><strong>Manual Verification</strong></summary>

<br>

### Public projects list response

<p align="center">
  <img src="https://github.com/user-attachments/assets/38f9db7d-34cb-4aa6-bc57-f40acee6d2e2" width="700" />
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/44df1abe-85b3-4016-9558-93f4e5f5a117" width="700" />
</p>


</details>

## Notes

This PR only implements `GET /api/projects`.
Project detail, project submission, and project upvote APIs will be handled separately.