### PR TITLE
feat: add project detail API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -125,6 +125,7 @@ public CorsConfigurationSource corsConfigurationSource() {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/events/**").permitAll()
                         // ── Public: Projects endpoint ────────────────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/{id}").permitAll()
                         // ── Public: Project categories endpoint ──────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
                         // ── Public: Swagger / OpenAPI ────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -1,8 +1,10 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.ProjectResponse;
 import com.sandeep.eventrabackend.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -54,6 +57,33 @@ public class ProjectController {
     })
     public ResponseEntity<List<ProjectResponse>> getAllProjects() {
         return ResponseEntity.ok(projectService.getAllProjects());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a project by ID",
+            description = "Returns details of a specific project by its ID."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Project fetched successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = ProjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Project not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<ProjectResponse> getProjectById(
+            @Parameter(description = "ID of the project")
+            @PathVariable Long id) {
+        return ResponseEntity.ok(projectService.getProjectById(id));
     }
 
     @GetMapping("/categories")

--- a/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/UserController.java
@@ -137,6 +137,7 @@ public class UserController {
         return ResponseEntity.ok(mapToUserProfileResponse(updatedUser));
     }
 
+/*
     @PutMapping("/profile")
     @Operation(
             summary = "Update authenticated user profile",
@@ -205,6 +206,7 @@ public class UserController {
                 )
         );
     }
+*/
 
     @GetMapping("/my-events")
     @Operation(

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -113,6 +113,18 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(ProjectNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleProjectNotFound(
+            ProjectNotFoundException ex,
+            HttpServletRequest request) {
+        return buildError(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                ex.getMessage(),
+                request
+        );
+    }
+
     private ResponseEntity<ErrorResponse> buildError(HttpStatus status, String error,
             String message, HttpServletRequest request) {
         ErrorResponse response = ErrorResponse.builder()

--- a/src/main/java/com/sandeep/eventrabackend/exception/ProjectNotFoundException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/ProjectNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class ProjectNotFoundException extends RuntimeException {
+    public ProjectNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.response.ProjectResponse;
+import com.sandeep.eventrabackend.exception.ProjectNotFoundException;
 import com.sandeep.eventrabackend.model.Project;
 import com.sandeep.eventrabackend.repository.ProjectRepository;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,13 @@ public class ProjectService {
         return projectRepository.findAll().stream()
                 .map(this::toProjectResponse)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectResponse getProjectById(Long id) {
+        return projectRepository.findById(id)
+                .map(this::toProjectResponse)
+                .orElseThrow(() -> new ProjectNotFoundException("Project not found with id: " + id));
     }
 
     private ProjectResponse toProjectResponse(Project project) {

--- a/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -86,4 +86,42 @@ public class ProjectControllerTests {
                         "Blockchain"
                 )));
     }
+
+    @Test
+    void testGetProjectById_Exists_ReturnsProject() throws Exception {
+        Project project = Project.builder()
+                .title("Single Project")
+                .description("Detail Description")
+                .category("Mobile Development")
+                .thumbnailUrl("http://example.com/single.png")
+                .githubUrl("http://github.com/test/single")
+                .upvotes(5)
+                .build();
+        project = projectRepository.save(project);
+
+        mockMvc.perform(get("/api/projects/" + project.getId())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(project.getId()))
+                .andExpect(jsonPath("$.title").value("Single Project"))
+                .andExpect(jsonPath("$.description").value("Detail Description"))
+                .andExpect(jsonPath("$.category").value("Mobile Development"))
+                .andExpect(jsonPath("$.thumbnailUrl").value("http://example.com/single.png"))
+                .andExpect(jsonPath("$.githubUrl").value("http://github.com/test/single"))
+                .andExpect(jsonPath("$.upvotes").value(5));
+    }
+
+    @Test
+    void testGetProjectById_NotFound_Returns404() throws Exception {
+        mockMvc.perform(get("/api/projects/999")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.message").value("Project not found with id: 999"))
+                .andExpect(jsonPath("$.path").value("/api/projects/999"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
 }


### PR DESCRIPTION
## Description

Adds the backend Project detail endpoint for retrieving a single project by ID.

## Changes Made

* Added `GET /api/projects/{id}`
* Reused the existing project model, repository, service, and response DTO structure
* Added project detail service logic with missing-project handling
* Added `ProjectNotFoundException`
* Added standard `404 Not Found` error handling for missing projects
* Added Swagger/OpenAPI documentation for the new endpoint
* Added tests for successful project detail retrieval and missing project handling
* Updated security configuration to allow public `GET` access for the project detail endpoint

## Verification

* Ran `./mvnw test -Dtest=ProjectControllerTests`
* Manually verified `GET /api/projects/1` returns `200 OK` with the expected project response
* Manually verified `GET /api/projects/999999` returns `404 Not Found` with the standard error response

<details>
<summary><strong>Screenshot 1 — Project detail retrieval returns 200 OK</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/07767dad-70a8-4465-a4df-d9be38ad1b64" width="700" />
</p>

</details>

<details>
<summary><strong>Screenshot 2 — Missing project returns 404 Not Found</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/dd8a8803-7b6e-4b02-bbb0-8d8fc12cb876" width="700" />
</p>

</details>

## Notes

This PR only implements the project detail retrieval endpoint.
Project submission and project upvote APIs will be handled separately.
A small startup/test unblocker was also applied for an existing duplicate `PUT /api/users/profile` mapping issue that prevented the Spring context from loading during verification.
