### PR TITLE
feat: add project creation API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.request.ProjectCreateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.ProjectResponse;
 import com.sandeep.eventrabackend.service.ProjectService;
@@ -10,12 +11,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -40,6 +42,48 @@ public class ProjectController {
             "IoT",
             "Blockchain"
     );
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Create a new project",
+            description = "Allows an ORGANIZER, ADMIN, or SUPER_ADMIN to create a new project.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Project created successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = ProjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid payload (validation failed)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User does not have the required role",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<ProjectResponse> createProject(
+            @Valid @RequestBody ProjectCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(projectService.createProject(request));
+    }
 
     @GetMapping
     @Operation(

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/ProjectCreateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/ProjectCreateRequest.java
@@ -1,0 +1,34 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request payload for creating a new project")
+public class ProjectCreateRequest {
+
+    @NotBlank(message = "Title is required")
+    @Schema(description = "Project title", example = "E-commerce Platform")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    @Schema(description = "Detailed project description", example = "A full-stack e-commerce solution.")
+    private String description;
+
+    @NotBlank(message = "Category is required")
+    @Schema(description = "Project category", example = "Web Development")
+    private String category;
+
+    @Schema(description = "URL to the project's thumbnail image", example = "https://example.com/thumb.png")
+    private String thumbnailUrl;
+
+    @Schema(description = "URL to the project's GitHub repository", example = "https://github.com/user/repo")
+    private String githubUrl;
+}

--- a/src/main/java/com/sandeep/eventrabackend/security/TokenBlacklistService.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/TokenBlacklistService.java
@@ -21,6 +21,14 @@ public class TokenBlacklistService {
         return blacklist.containsKey(token);
     }
 
+    /**
+     * Clears the entire blacklist.
+     * Primarily used for test isolation.
+     */
+    public void clear() {
+        blacklist.clear();
+    }
+
     // Clean up expired tokens every hour to prevent memory leaks
     @Scheduled(fixedRate = 3600000)
     public void cleanUpBlacklist() {

--- a/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.dto.request.ProjectCreateRequest;
 import com.sandeep.eventrabackend.dto.response.ProjectResponse;
 import com.sandeep.eventrabackend.exception.ProjectNotFoundException;
 import com.sandeep.eventrabackend.model.Project;
@@ -17,6 +18,20 @@ public class ProjectService {
 
     public ProjectService(ProjectRepository projectRepository) {
         this.projectRepository = projectRepository;
+    }
+
+    @Transactional
+    public ProjectResponse createProject(ProjectCreateRequest request) {
+        Project project = Project.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .category(request.getCategory())
+                .thumbnailUrl(request.getThumbnailUrl())
+                .githubUrl(request.getGithubUrl())
+                .build();
+
+        Project savedProject = projectRepository.save(project);
+        return toProjectResponse(savedProject);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/sandeep/eventrabackend/controller/AuthLogoutTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/AuthLogoutTests.java
@@ -39,10 +39,14 @@ public class AuthLogoutTests {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private com.sandeep.eventrabackend.security.TokenBlacklistService tokenBlacklistService;
+
     private String jwtToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        tokenBlacklistService.clear();
         userRepository.deleteAll();
 
         // Create a test user

--- a/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -1,5 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.ProjectCreateRequest;
 import com.sandeep.eventrabackend.model.Project;
 import com.sandeep.eventrabackend.repository.ProjectRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -16,6 +19,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -29,9 +33,79 @@ public class ProjectControllerTests {
     @Autowired
     private ProjectRepository projectRepository;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @BeforeEach
     void setUp() {
         projectRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void testCreateProject_Success_Returns201() throws Exception {
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("New Project")
+                .description("New Description")
+                .category("Web Development")
+                .thumbnailUrl("http://example.com/new.png")
+                .githubUrl("http://github.com/new/repo")
+                .build();
+
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("New Project"))
+                .andExpect(jsonPath("$.description").value("New Description"))
+                .andExpect(jsonPath("$.category").value("Web Development"))
+                .andExpect(jsonPath("$.thumbnailUrl").value("http://example.com/new.png"))
+                .andExpect(jsonPath("$.githubUrl").value("http://github.com/new/repo"))
+                .andExpect(jsonPath("$.upvotes").value(0));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void testCreateProject_ValidationFailure_Returns400() throws Exception {
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("") // Blank title
+                .description("New Description")
+                .category("Web Development")
+                .build();
+
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testCreateProject_Unauthenticated_Returns401() throws Exception {
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("New Project")
+                .description("New Description")
+                .category("Web Development")
+                .build();
+
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(authorities = "CLIENT")
+    void testCreateProject_ForbiddenRole_Returns403() throws Exception {
+        ProjectCreateRequest request = ProjectCreateRequest.builder()
+                .title("New Project")
+                .description("New Description")
+                .category("Web Development")
+                .build();
+
+        mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR implements the backend API for creating/submitting projects.

The new endpoint allows authorized users to create projects with required project details while keeping the existing Project GET APIs unchanged.

## Changes Made

- Added `POST /api/projects`
- Added `ProjectCreateRequest` DTO with validation
- Required `title`, `description`, and `category`
- Kept `thumbnailUrl` and `githubUrl` optional
- Set project `upvotes` to default as `0`
- Restricted project creation to `ORGANIZER`, `ADMIN`, and `SUPER_ADMIN`
- Returned `201 Created` with `ProjectResponse` on successful project creation
- Added Swagger/OpenAPI documentation for the new endpoint
- Added tests for:
  - successful project creation
  - validation failure
  - unauthenticated request
  - forbidden CLIENT role access
- Improved logout test isolation by clearing the in-memory token blacklist before each logout test

## Verification

- Ran full backend test suite successfully:

```bash
./mvnw clean test
```

- Verified all `63` tests passed successfully.

- Manually verified the new endpoint behavior:

| Scenario | Result |
|---|---|
| No token | `401 Unauthorized` |
| CLIENT token | `403 Forbidden` |
| ORGANIZER token with valid body | `201 Created` |
| Blank required field | `400 Bad Request` |

<details>
<summary><strong>Verification Evidence</strong></summary>

<br>

### Unauthorized Project Creation

<p align="center">
  <img src="https://github.com/user-attachments/assets/59dc6ba2-9472-4052-8529-8aef15462b77" width="700" />
</p>

### Forbidden for CLIENT Role

<p align="center">
  <img src="https://github.com/user-attachments/assets/41aa380c-449a-4baa-b2b0-4ff903271882" width="700" />
</p>

### Successful Project Creation

<p align="center">
  <img src="https://github.com/user-attachments/assets/2f17367a-3743-43e0-986c-65d1adecbf68" width="700" />
</p>

### Validation Failure

<p align="center">
  <img src="https://github.com/user-attachments/assets/9800ff97-f71c-4cc3-baf3-cd0bc047fda9" width="700" />
</p>

### Full Test Suite Passing

<p align="center">
  <img src="https://github.com/user-attachments/assets/83b80b62-ad01-4b94-bc98-932f0c1416bf" width="700" />
</p>

</details>

## Notes

This PR only implements `POST /api/projects`.
It does not implement `POST /api/projects/{id}/upvote`, and it does not modify the existing Project GET APIs, event pagination, auth APIs, user APIs, or unrelated event APIs.

