### PR TITLE
feat: add project upvote API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/ProjectController.java
@@ -147,4 +147,40 @@ public class ProjectController {
     public ResponseEntity<List<String>> getCategories() {
         return ResponseEntity.ok(CATEGORIES);
     }
+
+    @PostMapping("/{id}/upvote")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(
+            summary = "Upvote a project",
+            description = "Allows any authenticated user to increment the upvote count of a project by 1.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Project upvoted successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = ProjectResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Project not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<ProjectResponse> upvoteProject(
+            @Parameter(description = "ID of the project to upvote")
+            @PathVariable Long id) {
+        return ResponseEntity.ok(projectService.upvoteProject(id));
+    }
 }

--- a/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/ProjectRepository.java
@@ -2,8 +2,15 @@ package com.sandeep.eventrabackend.repository;
 
 import com.sandeep.eventrabackend.model.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+    @Modifying
+    @Query("UPDATE Project p SET p.upvotes = p.upvotes + 1 WHERE p.id = :id")
+    int incrementUpvotes(@Param("id") Long id);
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/ProjectService.java
@@ -48,6 +48,14 @@ public class ProjectService {
                 .orElseThrow(() -> new ProjectNotFoundException("Project not found with id: " + id));
     }
 
+    @Transactional
+    public ProjectResponse upvoteProject(Long id) {
+        if (projectRepository.incrementUpvotes(id) == 0) {
+            throw new ProjectNotFoundException("Project not found with id: " + id);
+        }
+        return getProjectById(id);
+    }
+
     private ProjectResponse toProjectResponse(Project project) {
         return ProjectResponse.builder()
                 .id(project.getId())

--- a/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/ProjectControllerTests.java
@@ -198,4 +198,38 @@ public class ProjectControllerTests {
                 .andExpect(jsonPath("$.path").value("/api/projects/999"))
                 .andExpect(jsonPath("$.timestamp").exists());
     }
+
+    @Test
+    @WithMockUser(authorities = "CLIENT")
+    void testUpvoteProject_Success_Returns200() throws Exception {
+        Project project = Project.builder()
+                .title("Upvote Project")
+                .description("Description")
+                .category("DevOps")
+                .upvotes(5)
+                .build();
+        project = projectRepository.save(project);
+
+        mockMvc.perform(post("/api/projects/" + project.getId() + "/upvote")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(project.getId()))
+                .andExpect(jsonPath("$.upvotes").value(6));
+    }
+
+    @Test
+    void testUpvoteProject_Unauthenticated_Returns401() throws Exception {
+        mockMvc.perform(post("/api/projects/1/upvote")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(authorities = "CLIENT")
+    void testUpvoteProject_NotFound_Returns404() throws Exception {
+        mockMvc.perform(post("/api/projects/999/upvote")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Project not found with id: 999"));
+    }
 }


### PR DESCRIPTION
## Description

This PR implements the backend API for upvoting projects.

The new endpoint allows any authenticated user to upvote an existing project. The implementation keeps the scope minimal by incrementing the existing `upvotes` count and returning the updated project response.

## Changes Made

* Added `POST /api/projects/{id}/upvote`
* Allowed any authenticated user to upvote a project
* Added atomic upvote increment logic in the repository
* Added service-layer handling for project upvotes
* Reused existing project not-found behavior for invalid project IDs
* Added Swagger/OpenAPI documentation for the new endpoint
* Added controller tests for:

  * successful authenticated upvote
  * unauthenticated request
  * missing project ID

## Notes

This PR does not implement duplicate-upvote prevention.

The current project model stores only a simple `upvotes` count. Preventing duplicate upvotes would require user-specific vote tracking through a separate table/entity, which is outside the scope of this minimal API PR.

## Verification

Manual verification was done using a project created through the H2 console.

<details>
<summary><strong>Screenshot 1 — Authenticated project upvote response</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/f168a082-fff8-4e5a-956c-9a3660a96e8a" width="700" />
</p>

</details>

<details>
<summary><strong>Screenshot 2 — H2 database confirms updated upvote count</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/6da87b75-f997-4640-bf8e-c480637d02ef" width="700" />
</p>

</details>