### PR TITLE
feat: add event stream API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -8,6 +8,7 @@ import com.sandeep.eventrabackend.dto.response.EventResponse;
 import com.sandeep.eventrabackend.dto.response.RegistrationResponse;
 import com.sandeep.eventrabackend.model.Event;
 import com.sandeep.eventrabackend.service.EventService;
+import com.sandeep.eventrabackend.service.EventStreamService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,10 +21,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 
 @RestController
@@ -35,9 +38,11 @@ import org.springframework.web.bind.annotation.*;
 public class EventController {
 
     private final EventService eventService;
+    private final EventStreamService eventStreamService;
 
-    public EventController(EventService eventService) {
+    public EventController(EventService eventService, EventStreamService eventStreamService) {
         this.eventService = eventService;
+        this.eventStreamService = eventStreamService;
     }
 
     // ── Issue #2102 — POST /api/events/create ────────────────────────────────
@@ -140,6 +145,23 @@ public class EventController {
 
         EventResponse updatedEvent = eventService.updateEvent(id, request);
         return ResponseEntity.ok(updatedEvent);
+    }
+
+    // ── GET /api/events/stream ───────────────────────────────────────────────
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Operation(
+            summary = "Stream event updates",
+            description = "Establishes a Server-Sent Events (SSE) connection to receive real-time event updates."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "SSE connection established"
+            )
+    })
+    public SseEmitter streamEvents() {
+        return eventStreamService.createEmitter();
     }
 
     // ── Issue #2101 — GET /api/events/{id} ──────────────────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventStreamService.java
@@ -1,0 +1,51 @@
+package com.sandeep.eventrabackend.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Service to manage Server-Sent Events (SSE) emitters for real-time updates.
+ */
+@Service
+public class EventStreamService {
+    private static final Logger log = LoggerFactory.getLogger(EventStreamService.class);
+    private static final Long DEFAULT_TIMEOUT = 300_000L; // 5 minutes
+
+    private final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    /**
+     * Creates a new SseEmitter, registers cleanup hooks, and sends an initial connection event.
+     *
+     * @return a configured SseEmitter
+     */
+    public SseEmitter createEmitter() {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+        emitter.onCompletion(() -> removeEmitter(emitter));
+        emitter.onTimeout(() -> removeEmitter(emitter));
+        emitter.onError((ex) -> removeEmitter(emitter));
+
+        emitters.add(emitter);
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connected")
+                    .data("Stream connected successfully"));
+        } catch (IOException e) {
+            log.error("Failed to send initial connection event", e);
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    private void removeEmitter(SseEmitter emitter) {
+        emitters.remove(emitter);
+    }
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/EventStreamTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/EventStreamTests.java
@@ -1,0 +1,27 @@
+package com.sandeep.eventrabackend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class EventStreamTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testEventStreamConnection() throws Exception {
+        mockMvc.perform(get("/api/events/stream"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM));
+    }
+}


### PR DESCRIPTION
## Description

This PR adds the backend API for establishing a Server-Sent Events stream connection for events.

The new endpoint allows clients to open a `text/event-stream` connection through `GET /api/events/stream`. It currently sends an initial `connected` event to confirm the stream is active and provides the foundation for future real-time event broadcasts.

## Changes Made

* Added `GET /api/events/stream`
* Added `EventStreamService` to manage active `SseEmitter` connections
* Added lifecycle cleanup for emitter completion, timeout, and errors
* Added an initial `connected` SSE event for manual verification
* Added test coverage for the SSE endpoint response
* Kept the endpoint public through the existing `GET /api/events/**` security rule

## Verification

* Verified the backend starts successfully
* Verified the SSE endpoint manually using:

```bash
curl -N http://localhost:8080/api/events/stream
```

Expected output:

```text
event:connected
data:Stream connected successfully
```

* Ran endpoint test:

```bash
./mvnw test -Dtest=EventStreamTests
```

<details>
<summary><strong>Manual Verification Screenshot</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/47f0c273-3a84-4e79-889e-263c2dee8e2f" width="700" />
</p>

</details>

## Notes

This PR only adds the basic SSE connection endpoint. It does not yet wire event creation, updates, registration, or availability changes into real-time broadcasts.
`GET /api/events` pagination is intentionally untouched because it is being handled separately.
