### PR TITLE
feat: add hackathons list API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -126,6 +126,8 @@ public CorsConfigurationSource corsConfigurationSource() {
                         // ── Public: Projects endpoint ────────────────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/{id}").permitAll()
+                        // ── Public: Hackathons endpoint ──────────────────────
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/hackathons").permitAll()
                         // ── Public: Project categories endpoint ──────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
                         // ── Public: Swagger / OpenAPI ────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -1,0 +1,47 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.dto.response.HackathonResponse;
+import com.sandeep.eventrabackend.service.HackathonService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/hackathons")
+@Tag(name = "Hackathons", description = "Endpoints for viewing and interacting with hackathons")
+public class HackathonController {
+
+    private final HackathonService hackathonService;
+
+    public HackathonController(HackathonService hackathonService) {
+        this.hackathonService = hackathonService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Get all hackathons",
+            description = "Returns a list of all available hackathons."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Hackathons fetched successfully",
+                    content = @Content(
+                            array = @ArraySchema(schema = @Schema(implementation = HackathonResponse.class))
+                    )
+            )
+    })
+    public ResponseEntity<List<HackathonResponse>> getAllHackathons() {
+        return ResponseEntity.ok(hackathonService.getAllHackathons());
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonResponse.java
@@ -1,0 +1,50 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response payload containing hackathon details")
+public class HackathonResponse {
+
+    @Schema(description = "Unique ID of the hackathon", example = "1")
+    private Long id;
+
+    @Schema(description = "Hackathon title", example = "Global AI Hackathon 2026")
+    private String title;
+
+    @Schema(description = "Detailed hackathon description", example = "A 48-hour hackathon focused on Generative AI.")
+    private String description;
+
+    @Schema(description = "Name of the organizing body", example = "Tech Innovators")
+    private String organizer;
+
+    @Schema(description = "Start date and time of the hackathon")
+    private LocalDateTime startDate;
+
+    @Schema(description = "End date and time of the hackathon")
+    private LocalDateTime endDate;
+
+    @Schema(description = "Physical or virtual location", example = "Hybrid / San Francisco")
+    private String location;
+
+    @Schema(description = "Mode of the hackathon", example = "Online")
+    private String mode;
+
+    @Schema(description = "Total prize pool description", example = "$50,000 in prizes")
+    private String prizePool;
+
+    @Schema(description = "Deadline for registration")
+    private LocalDateTime registrationDeadline;
+
+    @Schema(description = "URL to the hackathon's promotional image", example = "https://example.com/hackathon.png")
+    private String imageUrl;
+}

--- a/src/main/java/com/sandeep/eventrabackend/model/Hackathon.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Hackathon.java
@@ -1,0 +1,45 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "hackathons")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Hackathon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(nullable = false)
+    private String organizer;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private String location;
+
+    private String mode; // e.g., "Online", "In-person", "Hybrid"
+
+    private String prizePool;
+
+    private LocalDateTime registrationDeadline;
+
+    private String imageUrl;
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/HackathonRepository.java
@@ -1,0 +1,9 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.Hackathon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HackathonRepository extends JpaRepository<Hackathon, Long> {
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -1,0 +1,41 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.response.HackathonResponse;
+import com.sandeep.eventrabackend.model.Hackathon;
+import com.sandeep.eventrabackend.repository.HackathonRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class HackathonService {
+
+    private final HackathonRepository hackathonRepository;
+
+    public HackathonService(HackathonRepository hackathonRepository) {
+        this.hackathonRepository = hackathonRepository;
+    }
+
+    public List<HackathonResponse> getAllHackathons() {
+        return hackathonRepository.findAll().stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    private HackathonResponse mapToResponse(Hackathon hackathon) {
+        return HackathonResponse.builder()
+                .id(hackathon.getId())
+                .title(hackathon.getTitle())
+                .description(hackathon.getDescription())
+                .organizer(hackathon.getOrganizer())
+                .startDate(hackathon.getStartDate())
+                .endDate(hackathon.getEndDate())
+                .location(hackathon.getLocation())
+                .mode(hackathon.getMode())
+                .prizePool(hackathon.getPrizePool())
+                .registrationDeadline(hackathon.getRegistrationDeadline())
+                .imageUrl(hackathon.getImageUrl())
+                .build();
+    }
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
@@ -1,0 +1,78 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Hackathon;
+import com.sandeep.eventrabackend.repository.HackathonRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class HackathonControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private HackathonRepository hackathonRepository;
+
+    @BeforeEach
+    void setUp() {
+        hackathonRepository.deleteAll();
+    }
+
+    @Test
+    void getAllHackathons_ShouldReturnEmptyList_WhenNoHackathonsExist() throws Exception {
+        mockMvc.perform(get("/api/hackathons")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    void getAllHackathons_ShouldReturnHackathons_WhenHackathonsExist() throws Exception {
+        Hackathon hackathon = Hackathon.builder()
+                .title("Test Hackathon")
+                .description("Test Description")
+                .organizer("Test Organizer")
+                .startDate(LocalDateTime.now().plusDays(1))
+                .endDate(LocalDateTime.now().plusDays(2))
+                .location("Online")
+                .mode("Online")
+                .prizePool("$1000")
+                .registrationDeadline(LocalDateTime.now().plusHours(12))
+                .imageUrl("http://example.com/image.png")
+                .build();
+
+        hackathonRepository.save(hackathon);
+
+        mockMvc.perform(get("/api/hackathons")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title").value("Test Hackathon"))
+                .andExpect(jsonPath("$[0].organizer").value("Test Organizer"))
+                .andExpect(jsonPath("$[0].location").value("Online"));
+    }
+
+    @Test
+    void getAllHackathons_ShouldBePubliclyAccessible() throws Exception {
+        // No authentication provided
+        mockMvc.perform(get("/api/hackathons"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Description

This PR implements the public backend API for listing hackathons.

The new endpoint allows clients to fetch all available hackathons using `GET /api/hackathons`. The implementation introduces a separate Hackathon module to keep hackathon APIs isolated from existing Event and Project APIs.

## Changes Made

* Added `GET /api/hackathons`
* Added `Hackathon` entity
* Added `HackathonRepository`
* Added `HackathonResponse` DTO with Swagger annotations
* Added `HackathonService` for fetching and mapping hackathons
* Added `HackathonController`
* Added a precise public security rule for `GET /api/hackathons`
* Added controller tests for public access and JSON response behavior

## Verification

* Manually verified `GET /api/hackathons`
* Confirmed unauthenticated access works
* Confirmed the endpoint returns a JSON array
* Ran `HackathonControllerTests` successfully

<details>
<summary><strong>Manual Verification — GET /api/hackathons</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/04ed1b40-0113-400f-9507-59c0a89948ab" width="700" />
</p>

</details>

<details>
<summary><strong>Test Verification — HackathonControllerTests</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/75d751f4-f597-4519-9260-ad931357e1f9" width="700" />
</p>

</details>

## Notes

This PR only implements the list endpoint for hackathons.
It does not add hackathon detail, create, update, delete, registration, pagination, filters, or frontend changes. Those can be handled separately in future PRs.