### PR TITLE
feat: add hackathon detail API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -128,6 +128,7 @@ public CorsConfigurationSource corsConfigurationSource() {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/{id}").permitAll()
                         // ── Public: Hackathons endpoint ──────────────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/hackathons").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/hackathons/{id}").permitAll()
                         // ── Public: Project categories endpoint ──────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
                         // ── Public: Swagger / OpenAPI ────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -1,8 +1,10 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
 import com.sandeep.eventrabackend.service.HackathonService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,5 +46,32 @@ public class HackathonController {
     })
     public ResponseEntity<List<HackathonResponse>> getAllHackathons() {
         return ResponseEntity.ok(hackathonService.getAllHackathons());
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+            summary = "Get a hackathon by ID",
+            description = "Returns details of a specific hackathon by its ID."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Hackathon fetched successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = HackathonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Hackathon not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<HackathonResponse> getHackathonById(
+            @Parameter(description = "ID of the hackathon")
+            @PathVariable Long id) {
+        return ResponseEntity.ok(hackathonService.getHackathonById(id));
     }
 }

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -125,6 +125,18 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(HackathonNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleHackathonNotFound(
+            HackathonNotFoundException ex,
+            HttpServletRequest request) {
+        return buildError(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                ex.getMessage(),
+                request
+        );
+    }
+
     private ResponseEntity<ErrorResponse> buildError(HttpStatus status, String error,
             String message, HttpServletRequest request) {
         ErrorResponse response = ErrorResponse.builder()

--- a/src/main/java/com/sandeep/eventrabackend/exception/HackathonNotFoundException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/HackathonNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sandeep.eventrabackend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class HackathonNotFoundException extends RuntimeException {
+    public HackathonNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -1,9 +1,11 @@
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
+import com.sandeep.eventrabackend.exception.HackathonNotFoundException;
 import com.sandeep.eventrabackend.model.Hackathon;
 import com.sandeep.eventrabackend.repository.HackathonRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,10 +19,18 @@ public class HackathonService {
         this.hackathonRepository = hackathonRepository;
     }
 
+    @Transactional(readOnly = true)
     public List<HackathonResponse> getAllHackathons() {
         return hackathonRepository.findAll().stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public HackathonResponse getHackathonById(Long id) {
+        return hackathonRepository.findById(id)
+                .map(this::mapToResponse)
+                .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
     }
 
     private HackathonResponse mapToResponse(Hackathon hackathon) {

--- a/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
@@ -70,6 +70,39 @@ public class HackathonControllerTests {
     }
 
     @Test
+    void getHackathonById_ShouldReturnHackathon_WhenHackathonExists() throws Exception {
+        Hackathon hackathon = Hackathon.builder()
+                .title("Single Hackathon")
+                .organizer("Organizer X")
+                .build();
+        hackathon = hackathonRepository.save(hackathon);
+
+        mockMvc.perform(get("/api/hackathons/" + hackathon.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Single Hackathon"))
+                .andExpect(jsonPath("$.organizer").value("Organizer X"));
+    }
+
+    @Test
+    void getHackathonById_ShouldReturn404_WhenHackathonDoesNotExist() throws Exception {
+        mockMvc.perform(get("/api/hackathons/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Hackathon not found with id: 999"));
+    }
+
+    @Test
+    void getHackathonById_ShouldBePubliclyAccessible() throws Exception {
+        Hackathon hackathon = Hackathon.builder()
+                .title("Public Hackathon")
+                .organizer("Public Org")
+                .build();
+        hackathon = hackathonRepository.save(hackathon);
+
+        mockMvc.perform(get("/api/hackathons/" + hackathon.getId()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void getAllHackathons_ShouldBePubliclyAccessible() throws Exception {
         // No authentication provided
         mockMvc.perform(get("/api/hackathons"))


### PR DESCRIPTION
## Description

This PR implements the public backend API for retrieving hackathon details by ID.

The new endpoint allows clients to fetch a single hackathon using its ID while keeping the existing hackathon list endpoint unchanged.

## Changes Made

* Added `GET /api/hackathons/{id}`
* Added `HackathonNotFoundException` for missing hackathon records
* Updated global exception handling for hackathon 404 responses
* Added service-layer lookup logic for hackathon detail retrieval
* Reused the existing `HackathonResponse` DTO
* Added precise public access rule in `SecurityConfig`
* Added controller tests for:

  * Successful hackathon detail retrieval
  * Missing hackathon 404 handling
  * Public access without authentication

## Verification

* Ran `HackathonControllerTests`
* Manually verified:

  * `GET /api/hackathons`
  * `GET /api/hackathons/1`
  * `GET /api/hackathons/999`

<details>
<summary><strong>Manual Verification</strong></summary>

<br>

Public hackathon list, detail endpoint, and missing hackathon handling:

<p align="center">
  <img src="https://github.com/user-attachments/assets/2d934f39-e89f-4720-aba6-111d0555686f" width="700" />
</p>

H2 test data used for local verification:

<p align="center">
  <img src="https://github.com/user-attachments/assets/88b9b46b-71c7-46f8-8939-281fcb0b5eb3" width="700" />
</p>

</details>

## Notes

This PR only adds the hackathon detail endpoint. It does not implement hackathon create, update, delete, or registration APIs.
