### PR TITLE
[Critical] fix: make CORS allowed origins configurable via env var - production frontend completely blocked

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 
 @Configuration
 @EnableWebSecurity
@@ -34,6 +35,9 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final RateLimitingFilter rateLimitingFilter;
     private final UserDetailsService userDetailsService;
+
+    @Value("${app.cors.allowed-origins:http://localhost:3000,https://eventra.vercel.app,https://eventra.sandeepvashishtha.tech}")
+    private String allowedOrigins;
 
     public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
             RateLimitingFilter rateLimitingFilter,
@@ -47,36 +51,37 @@ public class SecurityConfig {
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
     @Bean
-public CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
 
-    CorsConfiguration configuration =
-            new CorsConfiguration();
+        String[] origins = allowedOrigins.split(",");
+        for (int i = 0; i < origins.length; i++) {
+            origins[i] = origins[i].trim();
+        }
+        configuration.setAllowedOrigins(List.of(origins));
 
-    configuration.setAllowedOrigins(
-            List.of("http://localhost:3000")
-    );
+        configuration.setAllowedMethods(
+                List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        );
 
-    configuration.setAllowedMethods(
-            List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")
-    );
+        configuration.setAllowedHeaders(
+                List.of("*")
+        );
 
-    configuration.setAllowedHeaders(
-            List.of("*")
-    );
+        configuration.setAllowCredentials(true);
 
-    configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
 
-    UrlBasedCorsConfigurationSource source =
-            new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration(
+                "/**",
+                configuration
+        );
 
-    source.registerCorsConfiguration(
-            "/**",
-            configuration
-    );
-
-    return source;
-}
+        return source;
+    }
 
     @Bean
     public DaoAuthenticationProvider authenticationProvider() {


### PR DESCRIPTION
## Description

### What was the issue?
The CORS configuration in SecurityConfig.java only allowed http://localhost:3000 - hardcoded with no way to configure it. The production frontend at https://eventra.sandeepvashishtha.tech and https://eventra.vercel.app was completely blocked from making API calls. Every cross-origin request failed the preflight OPTIONS check, making the entire frontend non-functional in production.

### Root Cause
`java
configuration.setAllowedOrigins(
    List.of("http://localhost:3000")  // Only localhost allowed
);
`

### Fix
- Externalized allowed origins to the CORS_ALLOWED_ORIGINS environment variable via @Value injection
- Added production frontend URLs as sensible defaults:
  - http://localhost:3000 (development)
  - https://eventra.vercel.app (Vercel production)
  - https://eventra.sandeepvashishtha.tech (custom domain)
- Origins are parsed from a comma-separated string for flexibility
- Added pp.cors.allowed-origins property to pplication.yml

### Additional Context
This is a **critical** production-blocking issue. Without this fix, no browser-based API call works in production - login, event creation, data fetching, everything is rejected by the browser. The backend is deployed but unusable from the frontend.

Closes #4641