### PR TITLE
[Critical] fix: remove weak JWT_SECRET default fallback - fail fast on missing env var

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
+++ b/src/main/java/com/sandeep/eventrabackend/security/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import jakarta.annotation.PostConstruct;
 import javax.crypto.SecretKey;
 import java.util.Date;
 
@@ -23,6 +24,21 @@ public class JwtTokenProvider {
 
     @Value("${app.jwt.expiration-ms}")
     private long jwtExpirationMs;
+
+    @PostConstruct
+    public void validateSecret() {
+        if (jwtSecret == null || jwtSecret.isBlank()) {
+            throw new IllegalStateException(
+                    "JWT_SECRET environment variable is not set. " +
+                    "Application cannot start without a valid JWT signing key. " +
+                    "Generate one with: openssl rand -base64 32"
+            );
+        }
+        if (jwtSecret.length() < 32) {
+            logger.warn("JWT_SECRET is shorter than 32 characters. " +
+                        "For production, use a 256-bit key: openssl rand -base64 32");
+        }
+    }
 
     private SecretKey getSigningKey() {
         byte[] keyBytes = Decoders.BASE64.decode(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,9 @@
 app:
   jwt:
-    secret: ${JWT_SECRET:change-this-secret-to-a-strong-256-bit-value-before-production}
+    secret: ${JWT_SECRET}
     expiration-ms: ${JWT_EXPIRATION_MS:86400000}
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://eventra.vercel.app,https://eventra.sandeepvashishtha.tech}
   rate-limit:
     enabled: ${RATE_LIMIT_ENABLED:true}
     login:


### PR DESCRIPTION
## Description

### What was the issue?
The JWT signing key had a hardcoded fallback value committed in the repo:
`yaml
secret: 
`

If the JWT_SECRET environment variable was not set (staging, dev, or misconfigured production), the application silently fell back to the literal string change-this-secret-to-a-strong-256-bit-value-before-production. This string is public in the GitHub repository.

### Impact
**Any attacker can forge valid JWT tokens for any user** - including admin roles. They can craft a token with ole: SUPER_ADMIN signed with this known string, and the backend accepts it as legitimate. This is a **critical** vulnerability.

### Fix
1. **Removed the default fallback** from pplication.yml: ${JWT_SECRET} now has no default, so Spring Boot fails to start when the env var is missing
2. **Added @PostConstruct validation** in JwtTokenProvider with:
   - Clear error message on missing JWT_SECRET with instructions to generate one
   - Warning log if the key is shorter than 32 characters
3. Also added CORS_ALLOWED_ORIGINS env var support in pplication.yml

### Additional Context
Generate a secure key with: openssl rand -base64 32

This is a **Pillar: Security** fix. The previous behavior meant anyone who read the repo could authenticate as any user.

Closes #4640