### PR TITLE
feat: add hackathon creation API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
 import com.sandeep.eventrabackend.service.HackathonService;
@@ -10,12 +11,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,6 +30,48 @@ public class HackathonController {
 
     public HackathonController(HackathonService hackathonService) {
         this.hackathonService = hackathonService;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Create a new hackathon",
+            description = "Allows an ORGANIZER, ADMIN, or SUPER_ADMIN to create a new hackathon.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Hackathon created successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = HackathonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid payload (validation failed)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User does not have the required role",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<HackathonResponse> createHackathon(
+            @Valid @RequestBody HackathonCreateRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.createHackathon(request));
     }
 
     @GetMapping

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/HackathonCreateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/HackathonCreateRequest.java
@@ -1,0 +1,61 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request payload for creating a new hackathon")
+public class HackathonCreateRequest {
+
+    @NotBlank(message = "Title is required")
+    @Schema(description = "Hackathon title", example = "Global AI Hackathon 2026")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    @Schema(description = "Detailed hackathon description", example = "A 48-hour hackathon focused on Generative AI.")
+    private String description;
+
+    @NotBlank(message = "Organizer is required")
+    @Schema(description = "Name of the organizing body", example = "Tech Innovators")
+    private String organizer;
+
+    @NotNull(message = "Start date is required")
+    @Future(message = "Start date must be in the future")
+    @Schema(description = "Start date and time of the hackathon")
+    private LocalDateTime startDate;
+
+    @NotNull(message = "End date is required")
+    @Future(message = "End date must be in the future")
+    @Schema(description = "End date and time of the hackathon")
+    private LocalDateTime endDate;
+
+    @NotBlank(message = "Location is required")
+    @Schema(description = "Physical or virtual location", example = "Hybrid / San Francisco")
+    private String location;
+
+    @NotBlank(message = "Mode is required")
+    @Schema(description = "Mode of the hackathon", example = "Online")
+    private String mode;
+
+    @Schema(description = "Total prize pool description", example = "$50,000 in prizes")
+    private String prizePool;
+
+    @NotNull(message = "Registration deadline is required")
+    @Future(message = "Registration deadline must be in the future")
+    @Schema(description = "Deadline for registration")
+    private LocalDateTime registrationDeadline;
+
+    @Schema(description = "URL to the hackathon's promotional image", example = "https://example.com/hackathon.png")
+    private String imageUrl;
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -1,5 +1,6 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
 import com.sandeep.eventrabackend.exception.HackathonNotFoundException;
 import com.sandeep.eventrabackend.model.Hackathon;
@@ -31,6 +32,25 @@ public class HackathonService {
         return hackathonRepository.findById(id)
                 .map(this::mapToResponse)
                 .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
+    }
+
+    @Transactional
+    public HackathonResponse createHackathon(HackathonCreateRequest request) {
+        Hackathon hackathon = Hackathon.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .organizer(request.getOrganizer())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .location(request.getLocation())
+                .mode(request.getMode())
+                .prizePool(request.getPrizePool())
+                .registrationDeadline(request.getRegistrationDeadline())
+                .imageUrl(request.getImageUrl())
+                .build();
+
+        Hackathon saved = hackathonRepository.save(hackathon);
+        return mapToResponse(saved);
     }
 
     private HackathonResponse mapToResponse(Hackathon hackathon) {

--- a/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
@@ -1,13 +1,16 @@
 package com.sandeep.eventrabackend.controller;
 
+import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
 import com.sandeep.eventrabackend.model.Hackathon;
 import com.sandeep.eventrabackend.repository.HackathonRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -15,6 +18,7 @@ import java.time.LocalDateTime;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -28,9 +32,78 @@ public class HackathonControllerTests {
     @Autowired
     private HackathonRepository hackathonRepository;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @BeforeEach
     void setUp() {
         hackathonRepository.deleteAll();
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void createHackathon_ShouldReturnCreated_WhenAuthorized() throws Exception {
+        HackathonCreateRequest request = HackathonCreateRequest.builder()
+                .title("New Hackathon")
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().plusDays(5))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .location("Virtual")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(2))
+                .build();
+
+        mockMvc.perform(post("/api/hackathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.title").value("New Hackathon"));
+    }
+
+    @Test
+    void createHackathon_ShouldReturn401_WhenUnauthenticated() throws Exception {
+        HackathonCreateRequest request = HackathonCreateRequest.builder()
+                .title("Unauthorized Hackathon")
+                .build();
+
+        mockMvc.perform(post("/api/hackathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(authorities = "CLIENT")
+    void createHackathon_ShouldReturn403_WhenForbidden() throws Exception {
+        HackathonCreateRequest request = HackathonCreateRequest.builder()
+                .title("Forbidden Hackathon")
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().plusDays(5))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .location("Virtual")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(2))
+                .build();
+
+        mockMvc.perform(post("/api/hackathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void createHackathon_ShouldReturn400_WhenInvalidPayload() throws Exception {
+        HackathonCreateRequest request = HackathonCreateRequest.builder()
+                .title("") // Invalid
+                .build();
+
+        mockMvc.perform(post("/api/hackathons")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR implements the backend API for creating hackathons.

The new endpoint allows authorized users to create hackathon records while keeping the existing public hackathon list and detail endpoints unchanged.

## Changes Made

* Added `POST /api/hackathons`
* Added `HackathonCreateRequest` DTO with validation
* Added service-layer logic for creating hackathons
* Reused the existing `HackathonResponse` DTO
* Protected the endpoint with role-based authorization
* Added controller tests for:

  * Successful creation by authorized users
  * Missing authentication
  * Insufficient permissions
  * Invalid request payload

## Verification

* Ran `HackathonControllerTests`
* Tests passed successfully

```text
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

<details>
<summary><strong>Manual Verification</strong></summary>

<br>

Created a hackathon successfully using `POST /api/hackathons` with a Bearer token.

<p align="center">
  <img src="https://github.com/user-attachments/assets/cfca3383-0825-4ab6-9226-4e1ac3b983d8" width="700" />
</p>

</details>

## Notes

This PR only implements hackathon creation. It does not modify the existing hackathon list/detail endpoints and does not implement hackathon update, delete, or registration APIs.