### PR TITLE
test: use test profile for event stream tests

### DIFF
--- a/src/test/java/com/sandeep/eventrabackend/controller/EventStreamTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/EventStreamTests.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 public class EventStreamTests {
 
     @Autowired


### PR DESCRIPTION
## Description

This PR fixes the CI test ApplicationContext failure in `EventStreamTests`.

After the unsafe JWT secret fallback was removed from production configuration, tests must use the existing test profile so they can load the dummy test-only JWT secret from `application-test.properties`.

`EventStreamTests` was the only `@SpringBootTest` class missing `@ActiveProfiles("test")`, so it attempted to load the default application configuration and required a real `JWT_SECRET` in CI.

## Changes Made

* Added `@ActiveProfiles("test")` to `EventStreamTests`
* Added the required `ActiveProfiles` import
* Kept production JWT behavior unchanged
* Did not reintroduce any default JWT secret fallback

## Verification

* Ran `./mvnw test -Dtest=EventStreamTests`
* Ran `./mvnw test`

```text
EventStreamTests: BUILD SUCCESS
Full test suite: 77 tests run, 0 failures
```

## Notes

This is a test-only configuration fix. It does not modify production security behavior or application endpoints.
(Fixes Swagger UI Test failure)