### PR TITLE
ci: fix backend test environment configuration

### DIFF
--- a/.github/workflows/master_eventra-backend-springboot.yml
+++ b/.github/workflows/master_eventra-backend-springboot.yml
@@ -27,10 +27,7 @@ jobs:
       - name: Build with Maven
         run: mvn clean install
         env:
-          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-          SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
-          SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
-          APP_JWT_SECRET: ${{ secrets.APP_JWT_SECRET }}
+          JWT_SECRET: ${{ secrets.APP_JWT_SECRET }}
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

This PR fixes the backend CI test environment configuration that was causing Spring ApplicationContext failures during the Maven build/test step.

The workflow was injecting production datasource environment variables into the Maven build step, which overrode the H2 test configuration from `application-test.properties`. It was also setting `APP_JWT_SECRET`, while the application configuration explicitly requires `JWT_SECRET`.

## Changes Made

- Removed production datasource environment variables from the Maven build/test step
- Added `JWT_SECRET` mapping using the existing `APP_JWT_SECRET` repository secret
- Allowed tests to use the H2 test configuration as intended
- Kept deployment/runtime behavior unchanged
- Did not modify application code, tests, or production JWT fallback behavior
- This change only removes production datasource variables from the Maven build/test step so tests can use H2. Runtime database configuration should remain in Azure App Service application settings.

## Verification

- Local full test suite passes successfully
- CI should now run Maven tests using H2 and the required JWT secret

```text
77 tests run, 0 failures