### PR TITLE
feat: add hackathon update API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -1,6 +1,7 @@
 package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
+import com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
 import com.sandeep.eventrabackend.service.HackathonService;
@@ -72,6 +73,57 @@ public class HackathonController {
     public ResponseEntity<HackathonResponse> createHackathon(
             @Valid @RequestBody HackathonCreateRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.createHackathon(request));
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ORGANIZER', 'ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Update an existing hackathon",
+            description = "Allows an ORGANIZER, ADMIN, or SUPER_ADMIN to update hackathon details.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Hackathon updated successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = HackathonResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid payload (validation failed)",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User does not have the required role",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Hackathon not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<HackathonResponse> updateHackathon(
+            @Parameter(description = "ID of the hackathon to update")
+            @PathVariable Long id,
+            @Valid @RequestBody HackathonUpdateRequest request) {
+        return ResponseEntity.ok(hackathonService.updateHackathon(id, request));
     }
 
     @GetMapping

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/HackathonUpdateRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/HackathonUpdateRequest.java
@@ -1,0 +1,61 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Request payload for updating an existing hackathon")
+public class HackathonUpdateRequest {
+
+    @NotBlank(message = "Title is required")
+    @Schema(description = "Hackathon title", example = "Global AI Hackathon 2026 Updated")
+    private String title;
+
+    @NotBlank(message = "Description is required")
+    @Schema(description = "Detailed hackathon description", example = "An updated deep dive into Generative AI.")
+    private String description;
+
+    @NotBlank(message = "Organizer is required")
+    @Schema(description = "Name of the organizing body", example = "Tech Innovators")
+    private String organizer;
+
+    @NotNull(message = "Start date is required")
+    @Future(message = "Start date must be in the future")
+    @Schema(description = "Start date and time of the hackathon")
+    private LocalDateTime startDate;
+
+    @NotNull(message = "End date is required")
+    @Future(message = "End date must be in the future")
+    @Schema(description = "End date and time of the hackathon")
+    private LocalDateTime endDate;
+
+    @NotBlank(message = "Location is required")
+    @Schema(description = "Physical or virtual location", example = "Hybrid / San Francisco")
+    private String location;
+
+    @NotBlank(message = "Mode is required")
+    @Schema(description = "Mode of the hackathon", example = "Online")
+    private String mode;
+
+    @Schema(description = "Total prize pool description", example = "$60,000 in prizes")
+    private String prizePool;
+
+    @NotNull(message = "Registration deadline is required")
+    @Future(message = "Registration deadline must be in the future")
+    @Schema(description = "Deadline for registration")
+    private LocalDateTime registrationDeadline;
+
+    @Schema(description = "URL to the hackathon's promotional image", example = "https://example.com/hackathon-updated.png")
+    private String imageUrl;
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -53,6 +53,26 @@ public class HackathonService {
         return mapToResponse(saved);
     }
 
+    @Transactional
+    public HackathonResponse updateHackathon(Long id, com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest request) {
+        Hackathon hackathon = hackathonRepository.findById(id)
+                .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
+
+        hackathon.setTitle(request.getTitle());
+        hackathon.setDescription(request.getDescription());
+        hackathon.setOrganizer(request.getOrganizer());
+        hackathon.setStartDate(request.getStartDate());
+        hackathon.setEndDate(request.getEndDate());
+        hackathon.setLocation(request.getLocation());
+        hackathon.setMode(request.getMode());
+        hackathon.setPrizePool(request.getPrizePool());
+        hackathon.setRegistrationDeadline(request.getRegistrationDeadline());
+        hackathon.setImageUrl(request.getImageUrl());
+
+        Hackathon updated = hackathonRepository.save(hackathon);
+        return mapToResponse(updated);
+    }
+
     private HackathonResponse mapToResponse(Hackathon hackathon) {
         return HackathonResponse.builder()
                 .id(hackathon.getId())

--- a/src/test/java/com/sandeep/eventrabackend/controller/HackathonUpdateTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/HackathonUpdateTests.java
@@ -1,0 +1,189 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest;
+import com.sandeep.eventrabackend.model.Hackathon;
+import com.sandeep.eventrabackend.repository.HackathonRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class HackathonUpdateTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private HackathonRepository hackathonRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Hackathon existingHackathon;
+
+    @BeforeEach
+    void setUp() {
+        hackathonRepository.deleteAll();
+
+        Hackathon hackathon = Hackathon.builder()
+                .title("Original Title")
+                .description("Original Description")
+                .organizer("Original Organizer")
+                .startDate(LocalDateTime.now().plusDays(5))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .location("Original Location")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(2))
+                .build();
+        existingHackathon = hackathonRepository.save(hackathon);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ORGANIZER")
+    @DisplayName("ORGANIZER can update hackathon successfully")
+    void testOrganizerCanUpdateHackathon() throws Exception {
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("Updated Title")
+                .description("Updated Description")
+                .organizer("Updated Organizer")
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(12))
+                .location("Updated Location")
+                .mode("In-person")
+                .registrationDeadline(LocalDateTime.now().plusDays(5))
+                .prizePool("$5000")
+                .imageUrl("http://example.com/updated.png")
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/" + existingHackathon.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Updated Title"))
+                .andExpect(jsonPath("$.location").value("Updated Location"))
+                .andExpect(jsonPath("$.mode").value("In-person"))
+                .andExpect(jsonPath("$.prizePool").value("$5000"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    @DisplayName("ADMIN can update hackathon successfully")
+    void testAdminCanUpdateHackathon() throws Exception {
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("Admin Updated Title")
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(12))
+                .location("Loc")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(5))
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/" + existingHackathon.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Admin Updated Title"));
+    }
+
+    @Test
+    @DisplayName("Unauthenticated request returns 401 Unauthorized")
+    void testUnauthenticatedUpdateReturns401() throws Exception {
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("Title")
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(12))
+                .location("Loc")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(5))
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/" + existingHackathon.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(authorities = "CLIENT")
+    @DisplayName("CLIENT role returns 403 Forbidden")
+    void testClientRoleReturns403() throws Exception {
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("Title")
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(12))
+                .location("Loc")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(5))
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/" + existingHackathon.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    @DisplayName("Non-existent hackathon id returns 404 Not Found")
+    void testUpdateNonExistentHackathonReturns404() throws Exception {
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("Title")
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().plusDays(10))
+                .endDate(LocalDateTime.now().plusDays(12))
+                .location("Loc")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(5))
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/9999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Hackathon not found with id: 9999"));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    @DisplayName("Invalid payload returns 400 Bad Request")
+    void testUpdateWithInvalidPayloadReturns400() throws Exception {
+        HackathonUpdateRequest request = HackathonUpdateRequest.builder()
+                .title("") // Blank title
+                .description("Desc")
+                .organizer("Org")
+                .startDate(LocalDateTime.now().minusDays(1)) // Past date
+                .endDate(LocalDateTime.now().plusDays(12))
+                .location("Loc")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(5))
+                .build();
+
+        mockMvc.perform(put("/api/hackathons/" + existingHackathon.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Description

This PR implements the `PUT /api/hackathons/{id}` backend API for updating an existing hackathon.

The endpoint allows authorized users to update hackathon details while reusing the existing Hackathon response structure and preserving the existing list, detail, and create hackathon APIs.

## Changes Made

* Added `PUT /api/hackathons/{id}`
* Added request validation for hackathon update payloads
* Added service-layer update logic for existing hackathons
* Reused existing `HackathonResponse` for the update response
* Added role-based access control for hackathon updates
* Added Swagger/OpenAPI documentation for the update endpoint
* Added focused tests for success, validation, unauthorized, forbidden, and not-found cases

## Authorization

This endpoint requires authentication and is restricted to:

* `ORGANIZER`
* `ADMIN`
* `SUPER_ADMIN`

## Verification

* Manually verified hackathon creation before update
* Manually verified successful hackathon update using `PUT /api/hackathons/{id}`
* Confirmed updated fields are returned correctly in the API response

<details>
<summary><strong>Manual Verification — Create Hackathon</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/b2b0462a-cc79-405b-a151-b8514470dd97" width="700" />
</p>

</details>

<details>
<summary><strong>Manual Verification — Update Hackathon</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/0dd4b587-d2bc-4aeb-989d-5e675bf6910d" width="700" />
</p>

</details>

## Notes

This PR only implements the hackathon update API. It does not modify existing Event, Project, Auth, User/Profile, Analytics, SSE, CI, or frontend code.
