### PR TITLE
feat: add hackathon delete API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -170,4 +170,45 @@ public class HackathonController {
             @PathVariable Long id) {
         return ResponseEntity.ok(hackathonService.getHackathonById(id));
     }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
+    @Operation(
+            summary = "Delete a hackathon",
+            description = "Allows an ADMIN or SUPER_ADMIN to delete a hackathon.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Hackathon deleted successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - User does not have the required role",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Hackathon not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<Void> deleteHackathon(
+            @Parameter(description = "ID of the hackathon to delete")
+            @PathVariable Long id) {
+        hackathonService.deleteHackathon(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -73,6 +73,14 @@ public class HackathonService {
         return mapToResponse(updated);
     }
 
+    @Transactional
+    public void deleteHackathon(Long id) {
+        if (!hackathonRepository.existsById(id)) {
+            throw new HackathonNotFoundException("Hackathon not found with id: " + id);
+        }
+        hackathonRepository.deleteById(id);
+    }
+
     private HackathonResponse mapToResponse(Hackathon hackathon) {
         return HackathonResponse.builder()
                 .id(hackathon.getId())

--- a/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/HackathonControllerTests.java
@@ -181,4 +181,60 @@ public class HackathonControllerTests {
         mockMvc.perform(get("/api/hackathons"))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void deleteHackathon_ShouldReturn204_WhenAdmin() throws Exception {
+        Hackathon hackathon = Hackathon.builder()
+                .title("Delete Me")
+                .organizer("Org")
+                .build();
+        hackathon = hackathonRepository.save(hackathon);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/hackathons/" + hackathon.getId()))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/hackathons/" + hackathon.getId()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(authorities = "SUPER_ADMIN")
+    void deleteHackathon_ShouldReturn204_WhenSuperAdmin() throws Exception {
+        Hackathon hackathon = Hackathon.builder()
+                .title("Delete Me Super")
+                .organizer("Org")
+                .build();
+        hackathon = hackathonRepository.save(hackathon);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/hackathons/" + hackathon.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ORGANIZER")
+    void deleteHackathon_ShouldReturn403_WhenOrganizer() throws Exception {
+        Hackathon hackathon = Hackathon.builder()
+                .title("No Delete Organizer")
+                .organizer("Org")
+                .build();
+        hackathon = hackathonRepository.save(hackathon);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/hackathons/" + hackathon.getId()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteHackathon_ShouldReturn401_WhenUnauthenticated() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/hackathons/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    void deleteHackathon_ShouldReturn404_WhenNotFound() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete("/api/hackathons/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Hackathon not found with id: 999"));
+    }
 }


### PR DESCRIPTION
## Description

This PR implements the `DELETE /api/hackathons/{id}` backend API for deleting an existing hackathon.

The endpoint allows high-privilege users to delete a hackathon by ID and returns `204 No Content` on successful deletion.

## Changes Made

* Added `DELETE /api/hackathons/{id}`
* Added service-layer delete logic for hackathons
* Added existence check before deletion
* Reused existing `HackathonNotFoundException` for missing hackathon IDs
* Added role-based access control for hackathon deletion
* Added Swagger/OpenAPI documentation for the delete endpoint
* Added tests for success, unauthorized, forbidden, and not-found cases

## Authorization

This endpoint requires authentication and is restricted to:

* `ADMIN`
* `SUPER_ADMIN`

## Verification

* Manually created a hackathon for delete testing
* Manually verified successful deletion using `DELETE /api/hackathons/{id}`
* Confirmed the endpoint returns `204 No Content`
* Confirmed fetching the deleted hackathon returns `404 Not Found`

<details>
<summary><strong>Manual Verification — Create Hackathon</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/9c5117c6-a0e2-4b71-9f4d-d697d0688151" width="700" />
</p>

</details>

<details>
<summary><strong>Manual Verification — Delete Hackathon</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/2f1b1016-6320-42e2-941d-92fe4176d506" width="700" />
</p>

</details>

## Notes

This PR only implements the hackathon delete API. It does not modify existing Event, Project, Auth, User/Profile, Analytics, SSE, CI, frontend, or hackathon registration code.
