### PR TITLE
feat: add hackathon registration API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/HackathonController.java
@@ -3,6 +3,7 @@ package com.sandeep.eventrabackend.controller;
 import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
 import com.sandeep.eventrabackend.dto.request.HackathonUpdateRequest;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
+import com.sandeep.eventrabackend.dto.response.HackathonRegistrationResponse;
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
 import com.sandeep.eventrabackend.service.HackathonService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +19,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,6 +33,57 @@ public class HackathonController {
 
     public HackathonController(HackathonService hackathonService) {
         this.hackathonService = hackathonService;
+    }
+
+    @PostMapping("/{id}/register")
+    @Operation(
+            summary = "Register for a hackathon",
+            description = "Allows an authenticated user to register for a specific hackathon.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Registered successfully",
+                    content = @Content(
+                            schema = @Schema(implementation = HackathonRegistrationResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Registration closed / invalid request",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Hackathon not found",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "Already registered",
+                    content = @Content(
+                            schema = @Schema(implementation = ErrorResponse.class)
+                    )
+            )
+    })
+    public ResponseEntity<HackathonRegistrationResponse> registerForHackathon(
+            @Parameter(description = "ID of the hackathon to register for")
+            @PathVariable Long id,
+            Authentication authentication) {
+        String userEmail = authentication.getName();
+        return ResponseEntity.status(HttpStatus.CREATED).body(hackathonService.registerUserForHackathon(id, userEmail));
     }
 
     @PostMapping

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonRegistrationResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/HackathonRegistrationResponse.java
@@ -1,0 +1,37 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Response returned after successfully registering for a hackathon")
+public class HackathonRegistrationResponse {
+
+    @Schema(description = "ID of the registration record.", example = "1")
+    private Long registrationId;
+
+    @Schema(description = "ID of the hackathon the user registered for.", example = "42")
+    private Long hackathonId;
+
+    @Schema(description = "Title of the hackathon.", example = "Global AI Hackathon")
+    private String hackathonTitle;
+
+    @Schema(description = "Email address of the registered user.", example = "alice@example.com")
+    private String userEmail;
+
+    @Schema(description = "Timestamp when the registration was confirmed.", example = "2025-06-01T10:30:00")
+    private LocalDateTime registeredAt;
+
+    @Schema(description = "Registration confirmation status.", example = "CONFIRMED")
+    private String status;
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -71,6 +71,13 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.BAD_REQUEST, "Bad Request", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(RegistrationClosedException.class)
+    public ResponseEntity<ErrorResponse> handleRegistrationClosed(
+            RegistrationClosedException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.BAD_REQUEST, "Registration Closed", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(EventFullException.class)
     public ResponseEntity<ErrorResponse> handleEventFull(
             EventFullException ex,

--- a/src/main/java/com/sandeep/eventrabackend/exception/RegistrationClosedException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/RegistrationClosedException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class RegistrationClosedException extends RuntimeException {
+    public RegistrationClosedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/model/HackathonRegistration.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/HackathonRegistration.java
@@ -1,0 +1,45 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "hackathon_registrations",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_hackathon_registration_hackathon_user",
+                columnNames = {"hackathon_id", "user_id"}
+        )
+)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HackathonRegistration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "hackathon_id", nullable = false)
+    private Hackathon hackathon;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreationTimestamp
+    @Column(name = "registered_at", nullable = false, updatable = false)
+    private LocalDateTime registeredAt;
+
+    @Column(nullable = false, length = 30)
+    @Builder.Default
+    private String status = "CONFIRMED";
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/HackathonRegistrationRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/HackathonRegistrationRepository.java
@@ -1,0 +1,13 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.HackathonRegistration;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HackathonRegistrationRepository extends JpaRepository<HackathonRegistration, Long> {
+
+    boolean existsByHackathon_IdAndUser_Email(Long hackathonId, String userEmail);
+
+    void deleteByHackathonId(Long hackathonId);
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/HackathonService.java
@@ -1,13 +1,22 @@
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.request.HackathonCreateRequest;
+import com.sandeep.eventrabackend.dto.response.HackathonRegistrationResponse;
 import com.sandeep.eventrabackend.dto.response.HackathonResponse;
 import com.sandeep.eventrabackend.exception.HackathonNotFoundException;
+import com.sandeep.eventrabackend.exception.RegistrationClosedException;
+import com.sandeep.eventrabackend.exception.RegistrationConflictException;
 import com.sandeep.eventrabackend.model.Hackathon;
+import com.sandeep.eventrabackend.model.HackathonRegistration;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
 import com.sandeep.eventrabackend.repository.HackathonRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,9 +24,15 @@ import java.util.stream.Collectors;
 public class HackathonService {
 
     private final HackathonRepository hackathonRepository;
+    private final HackathonRegistrationRepository hackathonRegistrationRepository;
+    private final UserRepository userRepository;
 
-    public HackathonService(HackathonRepository hackathonRepository) {
+    public HackathonService(HackathonRepository hackathonRepository,
+                            HackathonRegistrationRepository hackathonRegistrationRepository,
+                            UserRepository userRepository) {
         this.hackathonRepository = hackathonRepository;
+        this.hackathonRegistrationRepository = hackathonRegistrationRepository;
+        this.userRepository = userRepository;
     }
 
     @Transactional(readOnly = true)
@@ -74,10 +89,47 @@ public class HackathonService {
     }
 
     @Transactional
+    public HackathonRegistrationResponse registerUserForHackathon(Long id, String userEmail) {
+        Hackathon hackathon = hackathonRepository.findById(id)
+                .orElseThrow(() -> new HackathonNotFoundException("Hackathon not found with id: " + id));
+
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
+
+        // Duplicate registration check
+        if (hackathonRegistrationRepository.existsByHackathon_IdAndUser_Email(id, userEmail)) {
+            throw new RegistrationConflictException("You are already registered for this hackathon.");
+        }
+
+        // Deadline check
+        if (hackathon.getRegistrationDeadline() != null && LocalDateTime.now().isAfter(hackathon.getRegistrationDeadline())) {
+            throw new RegistrationClosedException("Registration deadline has passed for this hackathon.");
+        }
+
+        HackathonRegistration registration = HackathonRegistration.builder()
+                .hackathon(hackathon)
+                .user(user)
+                .status("CONFIRMED")
+                .build();
+
+        registration = hackathonRegistrationRepository.save(registration);
+
+        return HackathonRegistrationResponse.builder()
+                .registrationId(registration.getId())
+                .hackathonId(hackathon.getId())
+                .hackathonTitle(hackathon.getTitle())
+                .userEmail(user.getEmail())
+                .registeredAt(registration.getRegisteredAt())
+                .status(registration.getStatus())
+                .build();
+    }
+
+    @Transactional
     public void deleteHackathon(Long id) {
         if (!hackathonRepository.existsById(id)) {
             throw new HackathonNotFoundException("Hackathon not found with id: " + id);
         }
+        hackathonRegistrationRepository.deleteByHackathonId(id);
         hackathonRepository.deleteById(id);
     }
 

--- a/src/test/java/com/sandeep/eventrabackend/controller/HackathonRegistrationTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/HackathonRegistrationTests.java
@@ -1,0 +1,161 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Hackathon;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.HackathonRegistrationRepository;
+import com.sandeep.eventrabackend.repository.HackathonRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class HackathonRegistrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private HackathonRepository hackathonRepository;
+
+    @Autowired
+    private HackathonRegistrationRepository hackathonRegistrationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Long hackathonId;
+    private final String testUserEmail = "testuser@example.com";
+
+    @BeforeEach
+    void setUp() {
+        hackathonRegistrationRepository.deleteAll();
+        hackathonRepository.deleteAll();
+        userRepository.deleteAll();
+
+        Hackathon hackathon = Hackathon.builder()
+                .title("Test Hackathon")
+                .description("A test hackathon")
+                .organizer("Test Org")
+                .startDate(LocalDateTime.now().plusDays(5))
+                .endDate(LocalDateTime.now().plusDays(7))
+                .location("Online")
+                .mode("Online")
+                .registrationDeadline(LocalDateTime.now().plusDays(2))
+                .build();
+        hackathon = hackathonRepository.save(hackathon);
+        hackathonId = hackathon.getId();
+
+        User user = User.builder()
+                .firstName("Test")
+                .lastName("User")
+                .email(testUserEmail)
+                .username("testuser")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("POST /api/hackathons/{id}/register - Success (201)")
+    void testRegistrationSuccess() throws Exception {
+        mockMvc.perform(post("/api/hackathons/" + hackathonId + "/register")
+                        .with(user(testUserEmail)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.hackathonId").value(hackathonId))
+                .andExpect(jsonPath("$.hackathonTitle").value("Test Hackathon"))
+                .andExpect(jsonPath("$.userEmail").value(testUserEmail))
+                .andExpect(jsonPath("$.status").value("CONFIRMED"))
+                .andExpect(jsonPath("$.registeredAt").exists());
+    }
+
+    @Test
+    @DisplayName("POST /api/hackathons/{id}/register - Unauthorized (401)")
+    void testRegistrationUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/hackathons/" + hackathonId + "/register"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /api/hackathons/{id}/register - Not Found (404)")
+    void testRegistrationNotFound() throws Exception {
+        mockMvc.perform(post("/api/hackathons/9999/register")
+                        .with(user(testUserEmail)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/hackathons/{id}/register - Duplicate Registration (409)")
+    void testDuplicateRegistration() throws Exception {
+        // First registration
+        mockMvc.perform(post("/api/hackathons/" + hackathonId + "/register")
+                        .with(user(testUserEmail)))
+                .andExpect(status().isCreated());
+
+        // Second registration
+        mockMvc.perform(post("/api/hackathons/" + hackathonId + "/register")
+                        .with(user(testUserEmail)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("You are already registered for this hackathon."));
+    }
+
+    @Test
+    @DisplayName("POST /api/hackathons/{id}/register - After Deadline (400)")
+    void testRegistrationAfterDeadline() throws Exception {
+        Hackathon pastHackathon = Hackathon.builder()
+                .title("Past Hackathon")
+                .organizer("Past Org")
+                .registrationDeadline(LocalDateTime.now().minusDays(1))
+                .build();
+        pastHackathon = hackathonRepository.save(pastHackathon);
+
+        mockMvc.perform(post("/api/hackathons/" + pastHackathon.getId() + "/register")
+                        .with(user(testUserEmail)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Registration deadline has passed for this hackathon."));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/hackathons/{id} - Should also delete registrations")
+    void testDeleteHackathonCleanup() throws Exception {
+        // Register user
+        mockMvc.perform(post("/api/hackathons/" + hackathonId + "/register")
+                        .with(user(testUserEmail)))
+                .andExpect(status().isCreated());
+
+        // Delete hackathon (using with(user(...).authorities(...)) to simulate ADMIN)
+        mockMvc.perform(delete("/api/hackathons/" + hackathonId)
+                        .with(user("admin").authorities(new org.springframework.security.core.authority.SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isNoContent());
+
+        // Verify hackathon is gone
+        mockMvc.perform(get("/api/hackathons/" + hackathonId))
+                .andExpect(status().isNotFound());
+
+        // Verify registrations are gone
+        assertEquals(0, hackathonRegistrationRepository.count());
+    }
+}


### PR DESCRIPTION
## Description

This PR implements the `POST /api/hackathons/{id}/register` backend API for registering an authenticated user for a hackathon.

The endpoint follows the existing event registration pattern while staying within the current Hackathon model scope. It supports authenticated registration, prevents duplicate registrations, enforces the hackathon registration deadline, and returns a registration confirmation response.

## Changes Made

* Added `POST /api/hackathons/{id}/register`
* Added `HackathonRegistration` entity
* Added `HackathonRegistrationRepository`
* Added `HackathonRegistrationResponse` DTO
* Added service-layer registration logic
* Added duplicate registration prevention with `409 Conflict`
* Added registration deadline enforcement
* Added cleanup of hackathon registrations when deleting a hackathon
* Added `RegistrationClosedException`
* Added exception handling for closed registrations
* Added Swagger/OpenAPI documentation for the registration endpoint
* Added focused tests for success, unauthorized, not-found, duplicate registration, deadline enforcement, and delete cleanup cases

## Authorization

This endpoint requires Bearer JWT authentication.

Any authenticated user can register for a hackathon.

## Verification

* Manually created a hackathon for registration testing
* Logged in as a test user and used the JWT token for authentication
* Manually verified successful registration using `POST /api/hackathons/{id}/register`
* Confirmed the API returns a registration confirmation with `CONFIRMED` status

<details>
<summary><strong>Manual Verification — Register for Hackathon</strong></summary>

<br>

<p align="center">
  <img src="https://github.com/user-attachments/assets/b5758d0d-0e8b-47b4-b39d-a203d22b22e2" width="700" />
</p>

</details>

## Notes

This PR only implements hackathon registration. It does not modify Event, Project, Auth, User/Profile, Analytics, SSE, CI, frontend, or unrelated Hackathon API behavior.