### PR TITLE
feat: add feedback submission API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/FeedbackController.java
@@ -1,0 +1,57 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.dto.request.FeedbackRequest;
+import com.sandeep.eventrabackend.dto.response.ErrorResponse;
+import com.sandeep.eventrabackend.dto.response.FeedbackResponse;
+import com.sandeep.eventrabackend.service.FeedbackService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/feedback")
+@RequiredArgsConstructor
+@Tag(name = "Feedback", description = "Endpoints for submitting event feedback")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping
+    @Operation(
+            summary = "Submit feedback for an event",
+            description = "Allows an attendee to rate and comment on an event they registered for."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Feedback submitted successfully",
+                    content = @Content(schema = @Schema(implementation = FeedbackResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Validation error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - JWT required",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden - User not registered for event",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Event or User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Conflict - Duplicate feedback",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<FeedbackResponse> submitFeedback(
+            @Valid @RequestBody FeedbackRequest request,
+            Authentication authentication) {
+        
+        FeedbackResponse response = feedbackService.submitFeedback(authentication.getName(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/FeedbackRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/FeedbackRequest.java
@@ -1,0 +1,28 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackRequest {
+
+    @NotNull(message = "Event ID is required")
+    private Long eventId;
+
+    @NotNull(message = "Rating is required")
+    @Min(value = 1, message = "Rating must be at least 1")
+    @Max(value = 5, message = "Rating must be at most 5")
+    private Integer rating;
+
+    @Size(max = 1000, message = "Comment must not exceed 1000 characters")
+    private String comment;
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/FeedbackResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/FeedbackResponse.java
@@ -1,0 +1,21 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackResponse {
+    private Long id;
+    private Long eventId;
+    private Long userId;
+    private Integer rating;
+    private String comment;
+    private LocalDateTime submittedAt;
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/FeedbackAlreadyExistsException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/FeedbackAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class FeedbackAlreadyExistsException extends RuntimeException {
+    public FeedbackAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -92,6 +92,20 @@ public class GlobalExceptionHandler {
         return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
     }
 
+    @ExceptionHandler(FeedbackAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleFeedbackAlreadyExists(
+            FeedbackAlreadyExistsException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(UserNotRegisteredException.class)
+    public ResponseEntity<ErrorResponse> handleUserNotRegistered(
+            UserNotRegisteredException ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.FORBIDDEN, "Forbidden", ex.getMessage(), request);
+    }
+
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ErrorResponse> handleAccessDenied(
             AccessDeniedException ex,

--- a/src/main/java/com/sandeep/eventrabackend/exception/UserNotRegisteredException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/UserNotRegisteredException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class UserNotRegisteredException extends RuntimeException {
+    public UserNotRegisteredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/FeedbackAnalyticsRepository.java
@@ -38,4 +38,6 @@ public interface FeedbackAnalyticsRepository extends JpaRepository<Feedback, Lon
         ORDER BY f.rating
         """)
     List<Object[]> findRatingDistributionByEvent(@Param("eventId") Long eventId);
+
+    boolean existsByEvent_IdAndUser_Email(Long eventId, String email);
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/FeedbackService.java
@@ -1,0 +1,68 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.request.FeedbackRequest;
+import com.sandeep.eventrabackend.dto.response.FeedbackResponse;
+import com.sandeep.eventrabackend.exception.EventNotFoundException;
+import com.sandeep.eventrabackend.exception.FeedbackAlreadyExistsException;
+import com.sandeep.eventrabackend.exception.UserNotRegisteredException;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.Feedback;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.EventRegistrationRepository;
+import com.sandeep.eventrabackend.repository.EventRepository;
+import com.sandeep.eventrabackend.repository.FeedbackAnalyticsRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+
+    private final FeedbackAnalyticsRepository feedbackRepository;
+    private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+    private final EventRegistrationRepository registrationRepository;
+
+    @Transactional
+    public FeedbackResponse submitFeedback(String userEmail, FeedbackRequest request) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + userEmail));
+
+        Event event = eventRepository.findById(request.getEventId())
+                .orElseThrow(() -> new EventNotFoundException("Event not found with ID: " + request.getEventId()));
+
+        // Validate user is registered for the event
+        if (!registrationRepository.existsByEvent_IdAndUser_Email(event.getId(), userEmail)) {
+            throw new UserNotRegisteredException("You must be registered for the event to provide feedback.");
+        }
+
+        // Prevent duplicate feedback
+        if (feedbackRepository.existsByEvent_IdAndUser_Email(event.getId(), userEmail)) {
+            throw new FeedbackAlreadyExistsException("You have already submitted feedback for this event.");
+        }
+
+        Feedback feedback = new Feedback();
+        feedback.setUser(user);
+        feedback.setEvent(event);
+        feedback.setRating(request.getRating());
+        feedback.setComment(request.getComment());
+
+        Feedback savedFeedback = feedbackRepository.save(feedback);
+
+        return mapToResponse(savedFeedback);
+    }
+
+    private FeedbackResponse mapToResponse(Feedback feedback) {
+        return FeedbackResponse.builder()
+                .id(feedback.getId())
+                .eventId(feedback.getEvent().getId())
+                .userId(feedback.getUser().getId())
+                .rating(feedback.getRating())
+                .comment(feedback.getComment())
+                .submittedAt(feedback.getSubmittedAt())
+                .build();
+    }
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/FeedbackControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/FeedbackControllerTests.java
@@ -1,0 +1,201 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sandeep.eventrabackend.dto.request.FeedbackRequest;
+import com.sandeep.eventrabackend.model.Event;
+import com.sandeep.eventrabackend.model.EventRegistration;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class FeedbackControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private EventRegistrationRepository eventRegistrationRepository;
+
+    @Autowired
+    private FeedbackAnalyticsRepository feedbackRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Long eventId;
+    private final String testUserEmail = "feedbackuser@example.com";
+
+    @BeforeEach
+    void setUp() {
+        feedbackRepository.deleteAll();
+        eventRegistrationRepository.deleteAll();
+        eventRepository.deleteAll();
+        userRepository.deleteAll();
+
+        // Create a test user
+        User user = User.builder()
+                .firstName("Feedback")
+                .lastName("User")
+                .email(testUserEmail)
+                .username("feedbackuser")
+                .password(passwordEncoder.encode("password"))
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(user);
+
+        // Create a test event
+        Event event = new Event();
+        event.setTitle("Feedback Test Event");
+        event.setCapacity(10);
+        event.setEventDate(LocalDateTime.now().plusDays(5));
+        event.setPublic(true);
+        event = eventRepository.save(event);
+        eventId = event.getId();
+    }
+
+    @Test
+    @DisplayName("POST /api/feedback — Success")
+    void testFeedbackSuccess() throws Exception {
+        // Register user for event first
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(eventRepository.findById(eventId).orElseThrow());
+        registration.setUser(userRepository.findByEmail(testUserEmail).orElseThrow());
+        eventRegistrationRepository.save(registration);
+
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(eventId)
+                .rating(5)
+                .comment("Excellent event!")
+                .build();
+
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.eventId").value(eventId))
+                .andExpect(jsonPath("$.rating").value(5))
+                .andExpect(jsonPath("$.comment").value("Excellent event!"));
+    }
+
+    @Test
+    @DisplayName("POST /api/feedback — 400 Bad Request (Invalid Rating)")
+    void testFeedbackInvalidRating() throws Exception {
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(eventId)
+                .rating(6) // Max is 5
+                .comment("Bad rating")
+                .build();
+
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /api/feedback — 404 Not Found (Event)")
+    void testFeedbackEventNotFound() throws Exception {
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(99999L)
+                .rating(4)
+                .build();
+
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("POST /api/feedback — 403 Forbidden (Not Registered)")
+    void testFeedbackNotRegistered() throws Exception {
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(eventId)
+                .rating(4)
+                .build();
+
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("You must be registered for the event to provide feedback."));
+    }
+
+    @Test
+    @DisplayName("POST /api/feedback — 409 Conflict (Duplicate Feedback)")
+    void testFeedbackDuplicate() throws Exception {
+        // Register user for event
+        EventRegistration registration = new EventRegistration();
+        registration.setEvent(eventRepository.findById(eventId).orElseThrow());
+        registration.setUser(userRepository.findByEmail(testUserEmail).orElseThrow());
+        eventRegistrationRepository.save(registration);
+
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(eventId)
+                .rating(5)
+                .build();
+
+        // First submission
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        // Second submission
+        mockMvc.perform(post("/api/feedback")
+                        .with(user(testUserEmail))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("You have already submitted feedback for this event."));
+    }
+
+    @Test
+    @DisplayName("POST /api/feedback — 401 Unauthorized")
+    void testFeedbackUnauthorized() throws Exception {
+        FeedbackRequest request = FeedbackRequest.builder()
+                .eventId(eventId)
+                .rating(5)
+                .build();
+
+        mockMvc.perform(post("/api/feedback")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Description

This PR implements the backend API for submitting event feedback.

The new endpoint allows an authenticated user to submit feedback for an event after they have registered for it. It validates the event, authenticated user, and registration before saving feedback, and prevents duplicate feedback submissions for the same event-user pair.

The flow covered by this PR is:

1. User registers for an event.
2. User submits feedback for that registered event.
3. Backend validates the request.
4. Feedback is saved and returned with `201 Created`.
5. Duplicate submissions are rejected with `409 Conflict`.

## Changes Made

- Added `POST /api/feedback`
- Added `FeedbackController` for handling feedback submission requests
- Added `FeedbackService` for feedback submission logic
- Added `FeedbackRequest` DTO with validation
- Added `FeedbackResponse` DTO for returning submitted feedback details
- Reused the existing `FeedbackAnalyticsRepository` for feedback persistence
- Added duplicate feedback validation for the same event-user pair
- Added event registration validation before allowing feedback submission
- Added `FeedbackAlreadyExistsException`
- Added `UserNotRegisteredException`
- Updated `GlobalExceptionHandler` to return proper error responses for the new exceptions
- Added focused controller tests for the feedback submission flow

## API Added

| Method | Endpoint | Auth Required | Description |
|--------|----------|---------------|-------------|
| POST | `/api/feedback` | Yes | Submit feedback for an event |

## Request Body

    {
      "eventId": 1,
      "rating": 5,
      "comment": "Great event!"
    }

## Request Validation

| Field | Validation |
|-------|------------|
| `eventId` | Required |
| `rating` | Required, must be between `1` and `5` |
| `comment` | Optional, maximum `1000` characters |

## Success Response

Returns `201 Created` when feedback is submitted successfully.

    {
      "id": 1,
      "eventId": 1,
      "userId": 1,
      "rating": 5,
      "comment": "Great event!",
      "submittedAt": "2026-06-07T18:06:22.334156"
    }

## Error Handling

| Status Code | Scenario |
|------------|----------|
| `400 Bad Request` | Invalid request body or validation failure |
| `401 Unauthorized` | Request is made without authentication |
| `403 Forbidden` | Authenticated user is not registered for the event |
| `404 Not Found` | Event or authenticated user does not exist |
| `409 Conflict` | User has already submitted feedback for the event |

## Manual Verification

The endpoint was manually verified locally using PowerShell API calls with a valid JWT token.

Manual flow tested:

1. Created a test event in the local H2 database.
2. Logged in as a test user.
3. Registered the user for the event.
4. Submitted feedback successfully.
5. Submitted feedback again for the same event and confirmed duplicate feedback is rejected.

<details>
<summary><strong>Verification Evidence</strong></summary>

<br>

### Event Registration Before Feedback

The user was registered for the event successfully before submitting feedback.

<p align="center">
  <img src="https://github.com/user-attachments/assets/72b37699-3600-4f7c-a760-54ceefff2e06" width="700" />
</p>

### Successful Feedback Submission

The feedback submission returned the created feedback response with `eventId`, `userId`, `rating`, `comment`, and `submittedAt`.

<p align="center">
  <img src="https://github.com/user-attachments/assets/27085a3b-1270-4f31-b75c-543f61d23a03" width="700" />
</p>

### Duplicate Feedback Conflict

Submitting feedback again for the same event-user pair returned `409 Conflict`.

<p align="center">
  <img src="https://github.com/user-attachments/assets/d920ae8d-731d-4c34-a8d7-282515958f1a" width="700" />
</p>

</details>

## Tests Added

Added focused controller tests for `POST /api/feedback`.

Covered cases:

- Successful feedback submission
- Invalid rating validation
- Missing event handling
- User not registered for event
- Duplicate feedback submission
- Unauthenticated request

## Test Commands

Focused test:

    ./mvnw test -Dtest=FeedbackControllerTests

Full test suite:

    ./mvnw test

## Scope Note

This PR is limited to implementing `POST /api/feedback` only.

It does not implement:

- `GET /api/feedback/event/{eventId}`
- Notification APIs
- Admin APIs
- Leaderboard APIs
- Achievement APIs
- Frontend documentation changes
- Any unrelated event, project, hackathon, auth, or CI changes