### PR TITLE
feat: add notifications list API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -1,0 +1,49 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.dto.response.NotificationResponse;
+import com.sandeep.eventrabackend.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@Tag(name = "Notifications", description = "Endpoints for user notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Get notifications for the authenticated user",
+            description = "Returns a list of notifications for the currently logged-in user, sorted by newest first.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Notifications retrieved successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid"
+            )
+    })
+    public ResponseEntity<List<NotificationResponse>> getNotifications(Authentication authentication) {
+        String email = authentication.getName();
+        return ResponseEntity.ok(notificationService.getNotificationsForUser(email));
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/NotificationResponse.java
@@ -1,0 +1,32 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Response payload containing notification details")
+public class NotificationResponse {
+
+    @Schema(description = "Unique ID of the notification", example = "1")
+    private Long id;
+
+    @Schema(description = "Notification title", example = "Welcome to Eventra")
+    private String title;
+
+    @Schema(description = "Notification message content", example = "Thank you for joining our platform!")
+    private String message;
+
+    @Schema(description = "Whether the notification has been read", example = "false")
+    private boolean read;
+
+    @Schema(description = "Timestamp when the notification was created")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/sandeep/eventrabackend/model/Notification.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/Notification.java
@@ -1,0 +1,41 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "notifications")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String message;
+
+    @Builder.Default
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserEmailOrderByCreatedAtDesc(String email);
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
@@ -1,0 +1,36 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.response.NotificationResponse;
+import com.sandeep.eventrabackend.model.Notification;
+import com.sandeep.eventrabackend.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationService(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    public List<NotificationResponse> getNotificationsForUser(String email) {
+        List<Notification> notifications = notificationRepository.findByUserEmailOrderByCreatedAtDesc(email);
+        return notifications.stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+    }
+
+    private NotificationResponse mapToResponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .read(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java
@@ -1,0 +1,160 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.model.Notification;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.NotificationRepository;
+import com.sandeep.eventrabackend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class NotificationControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser1;
+    private User testUser2;
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.deleteAll();
+        userRepository.deleteAll();
+
+        testUser1 = User.builder()
+                .firstName("User1")
+                .lastName("Test")
+                .email("user1@example.com")
+                .username("user1")
+                .password("password")
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(testUser1);
+
+        testUser2 = User.builder()
+                .firstName("User2")
+                .lastName("Test")
+                .email("user2@example.com")
+                .username("user2")
+                .password("password")
+                .role(Role.CLIENT)
+                .build();
+        userRepository.save(testUser2);
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications returns empty list for user with no notifications")
+    void testGetNotificationsEmpty() throws Exception {
+        mockMvc.perform(get("/api/notifications")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications returns 401 for unauthenticated request")
+    void testGetNotificationsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/notifications"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications returns notifications for authenticated user")
+    void testGetNotificationsSuccess() throws Exception {
+        Notification n1 = Notification.builder()
+                .user(testUser1)
+                .title("Title 1")
+                .message("Message 1")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n1);
+
+        mockMvc.perform(get("/api/notifications")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title").value("Title 1"))
+                .andExpect(jsonPath("$[0].message").value("Message 1"))
+                .andExpect(jsonPath("$[0].read").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications filters notifications by user")
+    void testGetNotificationsIsolation() throws Exception {
+        Notification n1 = Notification.builder()
+                .user(testUser1)
+                .title("User 1 Notification")
+                .message("Secret")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n1);
+
+        Notification n2 = Notification.builder()
+                .user(testUser2)
+                .title("User 2 Notification")
+                .message("Secret")
+                .isRead(false)
+                .build();
+        notificationRepository.save(n2);
+
+        mockMvc.perform(get("/api/notifications")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].title").value("User 1 Notification"));
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications returns notifications sorted by newest first")
+    void testGetNotificationsSorting() throws Exception {
+        Notification oldNotification = Notification.builder()
+                .user(testUser1)
+                .title("Old")
+                .message("Old Message")
+                .isRead(false)
+                .build();
+        notificationRepository.save(oldNotification);
+
+        // Manually set creation time if possible, or just rely on sequence of saves
+        // Since we use @CreationTimestamp, the second save should have a later timestamp.
+        
+        Notification newNotification = Notification.builder()
+                .user(testUser1)
+                .title("New")
+                .message("New Message")
+                .isRead(false)
+                .build();
+        notificationRepository.save(newNotification);
+
+        mockMvc.perform(get("/api/notifications")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].title").value("New"))
+                .andExpect(jsonPath("$[1].title").value("Old"));
+    }
+}


### PR DESCRIPTION
## Description

This PR implements the authenticated notifications list API for Eventra.

The new endpoint allows logged-in users to fetch their own notifications only. Notifications are returned in newest-first order and include read/unread status.

## Changes Made

- Added `GET /api/notifications`
- Added `Notification` entity linked to `User`
- Added `NotificationRepository`
- Added `NotificationResponse` DTO
- Added `NotificationService`
- Added `NotificationController`
- Added focused controller tests for:
  - authenticated notification listing
  - unauthenticated access returning `401`
  - empty notification list
  - user-specific filtering
  - newest-first sorting

## API Behavior

| Method | Endpoint | Auth Required |
|--------|----------|---------------|
| GET | `/api/notifications` | Yes |

Returns `200 OK` with a JSON array of notifications for the authenticated user.

Example response:

```json
[
  {
    "id": 1,
    "title": "Welcome Notification",
    "message": "This is a manual test notification.",
    "read": false,
    "createdAt": "2026-06-09T00:38:52.335113"
  }
]
```

## Manual Testing

Manually tested the endpoint locally using PowerShell.

Steps verified:

- Logged in as a test user
- Inserted a notification manually into the local H2 database
- Called `GET /api/notifications` with the authenticated JWT token
- Confirmed the endpoint returned the authenticated user’s notification
- Confirmed the response includes `id`, `title`, `message`, `read`, and `createdAt`

## Screenshots

<details>
<summary>GET /api/notifications manual test</summary>

<img src="https://github.com/user-attachments/assets/9f12a704-3a9c-4127-bde0-9ddb46c8dbbe" width="700" alt="GET /api/notifications manual test" />

</details>

## Automated Testing

Focused test run:

```bash
mvn -Dtest=NotificationControllerTests test
```

Result:

```text
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Notes

- This PR only implements `GET /api/notifications`
- `PUT /api/notifications/{id}/read` is not implemented in this PR
- `PUT /api/notifications/read-all` is not implemented in this PR
- No notification generation triggers were added
- `SecurityConfig` was not modified because the existing authenticated default protects this endpoint
