### PR TITLE
feat: add notification read API

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/NotificationController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,5 +47,32 @@ public class NotificationController {
     public ResponseEntity<List<NotificationResponse>> getNotifications(Authentication authentication) {
         String email = authentication.getName();
         return ResponseEntity.ok(notificationService.getNotificationsForUser(email));
+    }
+
+    @PutMapping("/{id}/read")
+    @Operation(
+            summary = "Mark a notification as read",
+            description = "Marks the specified notification as read for the authenticated user.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Notification marked as read successfully"
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Unauthorized - JWT token missing or invalid"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Notification not found or does not belong to the user"
+            )
+    })
+    public ResponseEntity<NotificationResponse> markAsRead(
+            @PathVariable Long id,
+            Authentication authentication) {
+        String email = authentication.getName();
+        return ResponseEntity.ok(notificationService.markAsRead(id, email));
     }
 }

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -158,6 +158,18 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(NotificationNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotificationNotFound(
+            NotificationNotFoundException ex,
+            HttpServletRequest request) {
+        return buildError(
+                HttpStatus.NOT_FOUND,
+                "Not Found",
+                ex.getMessage(),
+                request
+        );
+    }
+
     private ResponseEntity<ErrorResponse> buildError(HttpStatus status, String error,
             String message, HttpServletRequest request) {
         ErrorResponse response = ErrorResponse.builder()

--- a/src/main/java/com/sandeep/eventrabackend/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/NotificationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class NotificationNotFoundException extends RuntimeException {
+    public NotificationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/NotificationRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserEmailOrderByCreatedAtDesc(String email);
+    Optional<Notification> findByIdAndUserEmail(Long id, String email);
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/NotificationService.java
@@ -1,9 +1,11 @@
 package com.sandeep.eventrabackend.service;
 
 import com.sandeep.eventrabackend.dto.response.NotificationResponse;
+import com.sandeep.eventrabackend.exception.NotificationNotFoundException;
 import com.sandeep.eventrabackend.model.Notification;
 import com.sandeep.eventrabackend.repository.NotificationRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,6 +24,16 @@ public class NotificationService {
         return notifications.stream()
                 .map(this::mapToResponse)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public NotificationResponse markAsRead(Long id, String email) {
+        Notification notification = notificationRepository.findByIdAndUserEmail(id, email)
+                .orElseThrow(() -> new NotificationNotFoundException("Notification not found with id: " + id));
+
+        notification.setRead(true);
+        Notification updatedNotification = notificationRepository.save(notification);
+        return mapToResponse(updatedNotification);
     }
 
     private NotificationResponse mapToResponse(Notification notification) {

--- a/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java
+++ b/src/test/java/com/sandeep/eventrabackend/controller/NotificationControllerTests.java
@@ -19,6 +19,7 @@ import java.time.LocalDateTime;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -139,9 +140,9 @@ public class NotificationControllerTests {
                 .build();
         notificationRepository.save(oldNotification);
 
-        // Manually set creation time if possible, or just rely on sequence of saves
-        // Since we use @CreationTimestamp, the second save should have a later timestamp.
-        
+        // Add small delay to ensure distinct @CreationTimestamp values
+        Thread.sleep(100);
+
         Notification newNotification = Notification.builder()
                 .user(testUser1)
                 .title("New")
@@ -156,5 +157,70 @@ public class NotificationControllerTests {
                 .andExpect(jsonPath("$", hasSize(2)))
                 .andExpect(jsonPath("$[0].title").value("New"))
                 .andExpect(jsonPath("$[1].title").value("Old"));
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/{id}/read marks own notification as read")
+    void testMarkAsReadSuccess() throws Exception {
+        Notification n1 = Notification.builder()
+                .user(testUser1)
+                .title("Unread")
+                .message("Msg")
+                .isRead(false)
+                .build();
+        n1 = notificationRepository.save(n1);
+
+        mockMvc.perform(put("/api/notifications/" + n1.getId() + "/read")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.read").value(true));
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/{id}/read returns 404 for non-existent notification")
+    void testMarkAsReadNotFound() throws Exception {
+        mockMvc.perform(put("/api/notifications/999/read")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/{id}/read returns 404 for another user's notification")
+    void testMarkAsReadIsolation() throws Exception {
+        Notification n2 = Notification.builder()
+                .user(testUser2)
+                .title("User 2 Notification")
+                .message("Secret")
+                .isRead(false)
+                .build();
+        n2 = notificationRepository.save(n2);
+
+        mockMvc.perform(put("/api/notifications/" + n2.getId() + "/read")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/{id}/read returns 401 for unauthenticated request")
+    void testMarkAsReadUnauthorized() throws Exception {
+        mockMvc.perform(put("/api/notifications/1/read"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PUT /api/notifications/{id}/read returns 200 for already-read notification")
+    void testMarkAsReadAlreadyRead() throws Exception {
+        Notification n1 = Notification.builder()
+                .user(testUser1)
+                .title("Read")
+                .message("Msg")
+                .isRead(true)
+                .build();
+        n1 = notificationRepository.save(n1);
+
+        mockMvc.perform(put("/api/notifications/" + n1.getId() + "/read")
+                        .with(user("user1@example.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.read").value(true));
     }
 }


### PR DESCRIPTION
## Description

This PR implements the authenticated API to mark a single notification as read.

## Changes Made

- Added `PUT /api/notifications/{id}/read`
- Added user-scoped notification lookup via `findByIdAndUserEmail`
- Added `NotificationNotFoundException`
- Added 404 handling for missing or unauthorized notification access
- Updated notification service/controller logic
- Added tests for success, unauthenticated access, not found, user isolation, and already-read behavior

## API Behavior

| Method | Endpoint | Auth Required |
|--------|----------|---------------|
| PUT | `/api/notifications/{id}/read` | Yes |

Returns `200 OK` with the updated notification response.

## Testing

- `mvn -Dtest=NotificationControllerTests test`
- `mvn -Dtest=UserProfileUpdateTests test`
- `mvn test`

Result: `110 tests passed`

## Notes

- This PR only implements `PUT /api/notifications/{id}/read`
- `PUT /api/notifications/read-all` is not implemented
- No notification triggers were added
- No CI workflow, README, or frontend docs changes were made