### PR TITLE
fix(cors): add production domain to allowed-origins default in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ app:
     secret: ${JWT_SECRET}
     expiration-ms: ${JWT_EXPIRATION_MS:86400000}
   cors:
-    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://eventra.vercel.app,https://eventra.sandeepvashishtha.tech}
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://eventra.vercel.app,https://eventra.sandeepvashishtha.tech,https://eventra.sandeepvashishtha.in}
   rate-limit:
     enabled: ${RATE_LIMIT_ENABLED:true}
     login:


### PR DESCRIPTION
## Related Issue
Resolves SandeepVashishtha/Eventra#8047
#62 

## Description
This PR updates the Spring Boot CORS configuration within `application.yml` to explicitly whitelist the production frontend domain (`https://eventra.sandeepvashishtha.in`).

### Changes Made
* Injected the production URL into the `allowed-origins` array in the environment configuration.

### Why
The server was dropping direct client side requests for user profiles and analytics streams because the origin header did not match the permitted list. Adding the explicit production URL allows the browser to read the HTTP responses directly without requiring a frontend proxy bypass.

## Checklist
* [x] YAML syntax verified
* [x] Production origin correctly formatted (no trailing slashes)