### PR TITLE
fix: add missing GET /api/events paginated endpoint

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/EventController.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +44,29 @@ public class EventController {
     public EventController(EventService eventService, EventStreamService eventStreamService) {
         this.eventService = eventService;
         this.eventStreamService = eventStreamService;
+    }
+
+    // ── GET /api/events — paginated public event feed ────────────────────────
+
+    @GetMapping
+    @Operation(
+            summary = "Get paginated public events",
+            description = "Returns a page of public events ordered by event date ascending. " +
+                          "Size is capped at 100 per request."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Events fetched successfully"
+            )
+    })
+    public ResponseEntity<Page<EventResponse>> getPublicEvents(
+            @Parameter(description = "Page number (0-indexed)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Number of events per page (max 100)", example = "24")
+            @RequestParam(defaultValue = "24") int size) {
+
+        return ResponseEntity.ok(eventService.getPublicEvents(page, size));
     }
 
     // ── Issue #2102 — POST /api/events/create ────────────────────────────────

--- a/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/GlobalExceptionHandler.java
@@ -14,6 +14,8 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;
@@ -111,6 +113,14 @@ public class GlobalExceptionHandler {
             AccessDeniedException ex,
             HttpServletRequest request) {
         return buildError(HttpStatus.FORBIDDEN, "Forbidden", "You do not have permission to access this resource", request);
+    }
+
+    @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
+    public ResponseEntity<ErrorResponse> handleNoRouteFound(
+            Exception ex,
+            HttpServletRequest request) {
+        return buildError(HttpStatus.NOT_FOUND, "Not Found",
+                "The requested resource was not found", request);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/EventRepository.java
@@ -2,6 +2,8 @@ package com.sandeep.eventrabackend.repository;
 
 import com.sandeep.eventrabackend.model.Event;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +13,8 @@ import java.util.Optional;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    Page<Event> findByIsPublicTrue(Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT e FROM Event e WHERE e.id = :id")

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -22,6 +22,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -113,6 +117,17 @@ public class EventService {
                 .orElseThrow(() ->
                         new EventNotFoundException(
                                 "Event not found with id: " + id));
+    }
+
+    /**
+     * Returns a paginated, date-ascending list of public events.
+     * Size is capped at 100 to prevent abuse.
+     */
+    @Transactional(readOnly = true)
+    public Page<EventResponse> getPublicEvents(int page, int size) {
+        int clampedSize = Math.min(size, 100);
+        Pageable pageable = PageRequest.of(page, clampedSize, Sort.by(Sort.Direction.ASC, "eventDate"));
+        return eventRepository.findByIsPublicTrue(pageable).map(this::toEventResponse);
     }
 
     /**


### PR DESCRIPTION
## 📌 Related Issue Fixes
Resolves SandeepVashishtha/Eventra#8790

## 📝 Description
This PR implements the missing paginated public events endpoint to resolve the 500 Internal Server Error that was breaking the frontend UI.

### 🔹 What has been changed?
* Added `GET /api/events` mapping in `EventController` with pagination support.
* Created `findByIsPublicTrue` in `EventRepository` to fetch valid events.
* Updated `GlobalExceptionHandler` to explicitly catch `NoHandlerFoundException` and return a 404 instead of a generic 500.

### 🔹 Why are these changes needed?
The frontend was attempting to fetch a paginated feed from a route that did not exist. The backend default exception handler was swallowing the missing route and returning a 500 status code. Building the explicit endpoint provides the data the UI expects and restores the trending events feed.