### PR TITLE
fix: return 401 instead of 500 for unauthenticated /api/auth/refresh

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.sandeep.eventrabackend.controller;
 
 import com.sandeep.eventrabackend.dto.request.LoginRequest;
 import com.sandeep.eventrabackend.dto.request.SignupRequest;
+import com.sandeep.eventrabackend.dto.request.GoogleAuthRequest;
 import com.sandeep.eventrabackend.dto.response.AuthResponse;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.service.AuthService;
@@ -16,7 +17,9 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import com.sandeep.eventrabackend.dto.request.GoogleAuthRequest;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -94,6 +97,22 @@ public class AuthController {
         AuthResponse response = authService.login(request);
         return ResponseEntity.ok(response);
     }
+
+        @PostMapping("/refresh")
+        @GetMapping("/refresh")
+        @SecurityRequirements
+        @Operation(summary = "Refresh access token",
+                        description = "Currently returns 401 — refresh-token flow not yet implemented.")
+        public ResponseEntity<ErrorResponse> refresh(HttpServletRequest request) {
+                ErrorResponse error = ErrorResponse.builder()
+                                .status(HttpStatus.UNAUTHORIZED.value())
+                                .error("Unauthorized")
+                                .message("No valid session. Please log in.")
+                                .path(request.getRequestURI())
+                                .timestamp(LocalDateTime.now())
+                                .build();
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+        }
 
 
 @PostMapping("/google")


### PR DESCRIPTION
Fixes #10081

## Root Cause
`/api/auth/refresh` has no backend implementation at all — no controller
mapping, no service method, no refresh-token model. The frontend calls it
unconditionally on the Login page before any session exists. Since the
route is unmapped, the request falls through to an unhandled-exception
path and returns a generic 500 instead of a proper auth-rejection response.

## Fix
Added a minimal `/api/auth/refresh` endpoint in `AuthController.java` that
returns `401 Unauthorized` with a structured `ErrorResponse` body, matching
the existing error format used across the app.

## Scope / Not Included
This is a **stub fix**, not a full refresh-token implementation. It only
corrects the status code (500 → 401) so the frontend's Login-page behavior
matches expected auth semantics. A real refresh-token flow (issuing/
validating refresh tokens, rotation, expiry) would need its own model,
service logic, and endpoint design — that's a separate, larger feature and
out of scope here.

## Tested
- `POST /api/auth/refresh` with no session → returns 401 with JSON error body
- No changes to existing `/signup`, `/login`, `/google`, `/logout` behavior