### PR TITLE
Add admin management endpoints

### DIFF
--- a/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
+++ b/src/main/java/com/sandeep/eventrabackend/config/SecurityConfig.java
@@ -136,6 +136,8 @@ public class SecurityConfig {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/hackathons/{id}").permitAll()
                         // ── Public: Project categories endpoint ──────────────
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/projects/categories").permitAll()
+                        // ── Admin Panel — ADMIN / SUPER_ADMIN only ────────
+                        .requestMatchers("/api/admin/**").hasAnyAuthority("ADMIN", "SUPER_ADMIN")
                         // ── Public: Swagger / OpenAPI ────────────────────
                         .requestMatchers(
                                 "/swagger-ui.html",

--- a/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/AdminController.java
@@ -1,0 +1,339 @@
+package com.sandeep.eventrabackend.controller;
+
+import com.sandeep.eventrabackend.dto.AdminDashboardStatsDTO;
+import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
+import com.sandeep.eventrabackend.dto.request.AdminUpdateRoleRequest;
+import com.sandeep.eventrabackend.dto.response.*;
+import com.sandeep.eventrabackend.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Admin Panel REST Controller.
+ *
+ * All endpoints are restricted to users with the ADMIN or SUPER_ADMIN role.
+ * Security is enforced at both the SecurityConfig level and via @PreAuthorize
+ * on each method.
+ *
+ * Base path: /api/admin
+ */
+@RestController
+@RequestMapping("/api/admin")
+@PreAuthorize("hasAnyAuthority('ADMIN', 'SUPER_ADMIN')")
+@Tag(name = "Admin Panel", description = "Admin-only endpoints for managing users, events, hackathons, feedback, and analytics")
+@SecurityRequirement(name = "bearerAuth")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. USER MANAGEMENT  —  /api/admin/users
+    // ══════════════════════════════════════════════════════════════════════
+
+    @GetMapping("/users")
+    @Operation(
+            summary = "List all users",
+            description = "Returns a paginated list of all registered users. " +
+                          "Optionally filter by role (CLIENT, ORGANIZER, ADMIN, SUPER_ADMIN)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Users fetched successfully",
+                    content = @Content(schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden — ADMIN role required",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<PagedResponse<AdminUserResponse>> getAllUsers(
+            @Parameter(description = "Page number (0-based)", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "Number of users per page", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(description = "Filter by role: CLIENT | ORGANIZER | ADMIN | SUPER_ADMIN")
+            @RequestParam(required = false) String role
+    ) {
+        return ResponseEntity.ok(adminService.getUsers(page, size, role));
+    }
+
+    @GetMapping("/users/{id}")
+    @Operation(
+            summary = "Get a user by ID",
+            description = "Returns full details of a single user including role and timestamps."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User found",
+                    content = @Content(schema = @Schema(implementation = AdminUserResponse.class))),
+            @ApiResponse(responseCode = "404", description = "User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AdminUserResponse> getUserById(
+            @Parameter(description = "ID of the user") @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(adminService.getUserById(id));
+    }
+
+    @PutMapping("/users/{id}/role")
+    @Operation(
+            summary = "Update a user's role",
+            description = "Changes the role of an existing user. " +
+                          "Valid roles: CLIENT, ORGANIZER, ADMIN, SUPER_ADMIN."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Role updated successfully",
+                    content = @Content(schema = @Schema(implementation = AdminUserResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid role value",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AdminUserResponse> updateUserRole(
+            @Parameter(description = "ID of the user to update") @PathVariable Long id,
+            @Valid @RequestBody AdminUpdateRoleRequest request
+    ) {
+        return ResponseEntity.ok(adminService.updateUserRole(id, request.getRole()));
+    }
+
+    @DeleteMapping("/users/{id}")
+    @Operation(
+            summary = "Delete a user",
+            description = "Permanently deletes a user account. Use with caution — this is irreversible."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "User deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "User not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteUser(
+            @Parameter(description = "ID of the user to delete") @PathVariable Long id
+    ) {
+        adminService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. EVENT MANAGEMENT  —  /api/admin/events
+    // ══════════════════════════════════════════════════════════════════════
+
+    @GetMapping("/events")
+    @Operation(
+            summary = "List all events (admin view)",
+            description = "Returns a paginated list of ALL events regardless of their visibility " +
+                          "(public or private), ordered by event date descending."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Events fetched successfully",
+                    content = @Content(schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<PagedResponse<EventResponse>> getAllEvents(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(adminService.getEvents(page, size));
+    }
+
+    @GetMapping("/events/{id}/attendees")
+    @Operation(
+            summary = "Get attendees of an event",
+            description = "Returns all users registered for a specific event."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Attendees fetched successfully",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = AdminUserResponse.class)))),
+            @ApiResponse(responseCode = "404", description = "Event not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<AdminUserResponse>> getEventAttendees(
+            @Parameter(description = "ID of the event") @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(adminService.getEventAttendees(id));
+    }
+
+    @DeleteMapping("/events/{id}")
+    @Operation(
+            summary = "Force-delete an event",
+            description = "Admin override to delete any event regardless of organizer ownership."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Event deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Event not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteEvent(
+            @Parameter(description = "ID of the event to delete") @PathVariable Long id
+    ) {
+        adminService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. HACKATHON MANAGEMENT  —  /api/admin/hackathons
+    // ══════════════════════════════════════════════════════════════════════
+
+    @GetMapping("/hackathons")
+    @Operation(
+            summary = "List all hackathons (admin view)",
+            description = "Returns a paginated list of all hackathons, ordered by start date descending."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Hackathons fetched successfully",
+                    content = @Content(schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<PagedResponse<HackathonResponse>> getAllHackathons(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(adminService.getHackathons(page, size));
+    }
+
+    @DeleteMapping("/hackathons/{id}")
+    @Operation(
+            summary = "Delete a hackathon",
+            description = "Permanently deletes a hackathon by ID."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Hackathon deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Hackathon not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteHackathon(
+            @Parameter(description = "ID of the hackathon to delete") @PathVariable Long id
+    ) {
+        adminService.deleteHackathon(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4. ANALYTICS  —  /api/admin/analytics
+    // ══════════════════════════════════════════════════════════════════════
+
+    @GetMapping("/analytics/dashboard")
+    @Operation(
+            summary = "Admin dashboard stats",
+            description = "Returns a comprehensive overview: total users (by role), events, " +
+                          "registrations, hackathons, and feedback metrics."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Dashboard stats fetched successfully",
+                    content = @Content(schema = @Schema(implementation = AdminDashboardStatsDTO.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AdminDashboardStatsDTO> getDashboardStats() {
+        return ResponseEntity.ok(adminService.getAdminDashboard());
+    }
+
+    @GetMapping("/analytics/users/growth")
+    @Operation(
+            summary = "User growth trend",
+            description = "Returns monthly registration trend data for the past N months. " +
+                          "Useful for plotting user growth charts in the admin panel."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "User growth trend fetched successfully",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = RegistrationTrendDTO.class)))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<RegistrationTrendDTO>> getUserGrowthTrend(
+            @Parameter(description = "Number of months to look back", example = "6")
+            @RequestParam(defaultValue = "6") int months
+    ) {
+        return ResponseEntity.ok(adminService.getUserGrowthTrend(months));
+    }
+
+    @GetMapping("/analytics/events/popular")
+    @Operation(
+            summary = "Most popular events",
+            description = "Returns the top N events ordered by registration count, " +
+                          "including capacity utilization percentage."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Popular events fetched successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<Map<String, Object>>> getPopularEvents(
+            @Parameter(description = "Maximum number of events to return", example = "10")
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        return ResponseEntity.ok(adminService.getPopularEvents(limit));
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 5. FEEDBACK MANAGEMENT  —  /api/admin/feedback
+    // ══════════════════════════════════════════════════════════════════════
+
+    @GetMapping("/feedback")
+    @Operation(
+            summary = "List all feedback",
+            description = "Returns a paginated list of all feedback submissions across all events, " +
+                          "ordered by submission date descending."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Feedback fetched successfully",
+                    content = @Content(schema = @Schema(implementation = PagedResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<PagedResponse<AdminFeedbackResponse>> getAllFeedback(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ResponseEntity.ok(adminService.getAllFeedback(page, size));
+    }
+
+    @DeleteMapping("/feedback/{id}")
+    @Operation(
+            summary = "Delete a feedback entry",
+            description = "Permanently removes a feedback entry by ID."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Feedback deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Feedback not found",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteFeedback(
+            @Parameter(description = "ID of the feedback to delete") @PathVariable Long id
+    ) {
+        adminService.deleteFeedback(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/AdminDashboardStatsDTO.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/AdminDashboardStatsDTO.java
@@ -1,0 +1,37 @@
+package com.sandeep.eventrabackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminDashboardStatsDTO {
+
+    // ── Users ──────────────────────────────────────────────────────────────
+    private long totalUsers;
+    private long newUsersThisMonth;
+    private long totalAdmins;
+    private long totalOrganizers;
+    private long totalClients;
+
+    // ── Events ─────────────────────────────────────────────────────────────
+    private long totalEvents;
+    private long activeEvents;
+    private long completedEvents;
+
+    // ── Registrations ──────────────────────────────────────────────────────
+    private long totalRegistrations;
+    private long uniqueParticipants;
+    private double averageCapacityUtilization;
+
+    // ── Hackathons ─────────────────────────────────────────────────────────
+    private long totalHackathons;
+
+    // ── Feedback ───────────────────────────────────────────────────────────
+    private long totalFeedbackSubmissions;
+    private double overallAverageRating;
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/AdminUpdateRoleRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/AdminUpdateRoleRequest.java
@@ -1,0 +1,16 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Request body for updating a user's role")
+public class AdminUpdateRoleRequest {
+
+    @NotNull(message = "Role must not be null")
+    @Schema(description = "New role to assign to the user", example = "ORGANIZER",
+            allowableValues = {"CLIENT", "ORGANIZER", "ADMIN", "SUPER_ADMIN"})
+    private String role;
+
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/AdminFeedbackResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/AdminFeedbackResponse.java
@@ -1,0 +1,41 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Admin view of a feedback entry")
+public class AdminFeedbackResponse {
+
+    @Schema(description = "Feedback ID", example = "1")
+    private Long id;
+
+    @Schema(description = "ID of the event the feedback belongs to", example = "5")
+    private Long eventId;
+
+    @Schema(description = "Title of the event", example = "Tech Conference 2026")
+    private String eventTitle;
+
+    @Schema(description = "ID of the user who submitted the feedback", example = "12")
+    private Long userId;
+
+    @Schema(description = "Username of the reviewer", example = "john_doe")
+    private String username;
+
+    @Schema(description = "Rating from 1–5", example = "4")
+    private Integer rating;
+
+    @Schema(description = "Optional comment", example = "Great event!")
+    private String comment;
+
+    @Schema(description = "Timestamp when feedback was submitted")
+    private LocalDateTime submittedAt;
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/AdminUserResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/AdminUserResponse.java
@@ -1,0 +1,43 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "Admin view of a user — includes sensitive fields like role and createdAt")
+public class AdminUserResponse {
+
+    @Schema(description = "User ID", example = "1")
+    private Long id;
+
+    @Schema(description = "First name", example = "John")
+    private String firstName;
+
+    @Schema(description = "Last name", example = "Doe")
+    private String lastName;
+
+    @Schema(description = "Unique username", example = "john_doe")
+    private String username;
+
+    @Schema(description = "Email address", example = "john@example.com")
+    private String email;
+
+    @Schema(description = "User role", example = "CLIENT")
+    private String role;
+
+    @Schema(description = "Account creation timestamp")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "Last update timestamp")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/response/PagedResponse.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/response/PagedResponse.java
@@ -1,0 +1,50 @@
+package com.sandeep.eventrabackend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "Generic paginated response wrapper")
+public class PagedResponse<T> {
+
+    @Schema(description = "List of items in the current page")
+    private List<T> content;
+
+    @Schema(description = "Current page number (0-indexed)", example = "0")
+    private int page;
+
+    @Schema(description = "Number of items per page", example = "10")
+    private int size;
+
+    @Schema(description = "Total number of items across all pages", example = "50")
+    private long totalElements;
+
+    @Schema(description = "Total number of pages", example = "5")
+    private int totalPages;
+
+    @Schema(description = "Whether this is the last page", example = "false")
+    private boolean last;
+
+    /**
+     * Convenience factory — builds a PagedResponse from a Spring {@link Page}.
+     */
+    public static <T> PagedResponse<T> from(Page<T> page) {
+        return PagedResponse.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .last(page.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package com.sandeep.eventrabackend.repository;
 
+import com.sandeep.eventrabackend.model.Role;
 import com.sandeep.eventrabackend.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +22,15 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByUsername(String username);
+
+    // ── Admin panel queries ────────────────────────────────────────────────
+
+    /** Returns all users with a specific role, paginated. */
+    Page<User> findByRole(Role role, Pageable pageable);
+
+    /** Count users created after the given timestamp — used for growth stats. */
+    long countByCreatedAtAfter(LocalDateTime date);
+
+    /** Count users by role — used for admin dashboard breakdown. */
+    long countByRole(Role role);
 }

--- a/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/AdminService.java
@@ -1,0 +1,322 @@
+package com.sandeep.eventrabackend.service;
+
+import com.sandeep.eventrabackend.dto.AdminDashboardStatsDTO;
+import com.sandeep.eventrabackend.dto.RegistrationTrendDTO;
+import com.sandeep.eventrabackend.dto.response.*;
+import com.sandeep.eventrabackend.model.Feedback;
+import com.sandeep.eventrabackend.model.Hackathon;
+import com.sandeep.eventrabackend.model.Role;
+import com.sandeep.eventrabackend.model.User;
+import com.sandeep.eventrabackend.repository.*;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Central service for all Admin Panel operations.
+ * All public methods are intended to be called from AdminController,
+ * which enforces ADMIN / SUPER_ADMIN role checks via @PreAuthorize.
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository              userRepository;
+    private final EventRepository             eventRepository;
+    private final HackathonRepository         hackathonRepository;
+    private final FeedbackAnalyticsRepository feedbackRepository;
+    private final EventAnalyticsRepository    eventAnalyticsRepo;
+    private final RegistrationAnalyticsRepository regRepo;
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 1. USER MANAGEMENT
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns all users, optionally filtered by role.
+     *
+     * @param page page index (0-based)
+     * @param size page size
+     * @param role optional role filter (e.g. "CLIENT") — null means all users
+     */
+    public PagedResponse<AdminUserResponse> getUsers(int page, int size, String role) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<User> userPage;
+
+        if (role != null && !role.isBlank()) {
+            Role roleEnum = parseRole(role);
+            userPage = userRepository.findByRole(roleEnum, pageable);
+        } else {
+            userPage = userRepository.findAll(pageable);
+        }
+
+        return PagedResponse.from(userPage.map(this::toAdminUserResponse));
+    }
+
+    /**
+     * Returns a single user by ID.
+     */
+    public AdminUserResponse getUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
+        return toAdminUserResponse(user);
+    }
+
+    /**
+     * Updates the role of a user.
+     */
+    @Transactional
+    public AdminUserResponse updateUserRole(Long id, String newRole) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + id));
+        user.setRole(parseRole(newRole));
+        return toAdminUserResponse(userRepository.save(user));
+    }
+
+    /**
+     * Deletes a user by ID.
+     */
+    @Transactional
+    public void deleteUser(Long id) {
+        if (!userRepository.existsById(id)) {
+            throw new EntityNotFoundException("User not found with id: " + id);
+        }
+        userRepository.deleteById(id);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 2. EVENT MANAGEMENT
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns all events (paginated), visible to admin regardless of isPublic.
+     */
+    public PagedResponse<EventResponse> getEvents(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("eventDate").descending());
+        return PagedResponse.from(eventRepository.findAll(pageable).map(this::toEventResponse));
+    }
+
+    /**
+     * Returns all attendees registered for a specific event.
+     */
+    public List<AdminUserResponse> getEventAttendees(Long eventId) {
+        var event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EntityNotFoundException("Event not found with id: " + eventId));
+        return event.getAttendees().stream()
+                .map(this::toAdminUserResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Force-deletes an event (admin override, bypasses organizer ownership).
+     */
+    @Transactional
+    public void deleteEvent(Long id) {
+        if (!eventRepository.existsById(id)) {
+            throw new EntityNotFoundException("Event not found with id: " + id);
+        }
+        eventRepository.deleteById(id);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 3. HACKATHON MANAGEMENT
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns all hackathons (paginated).
+     */
+    public PagedResponse<HackathonResponse> getHackathons(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("startDate").descending());
+        return PagedResponse.from(hackathonRepository.findAll(pageable).map(this::toHackathonResponse));
+    }
+
+    /**
+     * Deletes a hackathon by ID.
+     */
+    @Transactional
+    public void deleteHackathon(Long id) {
+        if (!hackathonRepository.existsById(id)) {
+            throw new EntityNotFoundException("Hackathon not found with id: " + id);
+        }
+        hackathonRepository.deleteById(id);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 4. ANALYTICS
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns an extended admin dashboard with user, event, hackathon, and feedback stats.
+     */
+    public AdminDashboardStatsDTO getAdminDashboard() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startOfMonth = now.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+
+        return AdminDashboardStatsDTO.builder()
+                // Users
+                .totalUsers(userRepository.count())
+                .newUsersThisMonth(userRepository.countByCreatedAtAfter(startOfMonth))
+                .totalAdmins(userRepository.countByRole(Role.ADMIN))
+                .totalOrganizers(userRepository.countByRole(Role.ORGANIZER))
+                .totalClients(userRepository.countByRole(Role.CLIENT))
+                // Events
+                .totalEvents(eventAnalyticsRepo.count())
+                .activeEvents(eventAnalyticsRepo.countActiveEvents(now))
+                .completedEvents(eventAnalyticsRepo.countCompletedEvents(now))
+                // Registrations
+                .totalRegistrations(regRepo.countConfirmedRegistrations())
+                .uniqueParticipants(eventAnalyticsRepo.countUniqueParticipants())
+                .averageCapacityUtilization(
+                        Optional.ofNullable(eventAnalyticsRepo.findAverageCapacityUtilization()).orElse(0.0))
+                // Hackathons
+                .totalHackathons(hackathonRepository.count())
+                // Feedback
+                .totalFeedbackSubmissions(feedbackRepository.countTotalFeedback())
+                .overallAverageRating(
+                        Optional.ofNullable(feedbackRepository.findOverallAverageRating()).orElse(0.0))
+                .build();
+    }
+
+    /**
+     * Returns user registration growth trend (monthly by default).
+     */
+    public List<RegistrationTrendDTO> getUserGrowthTrend(int months) {
+        // Reuse existing registration trend from AnalyticsService logic
+        LocalDateTime from = LocalDateTime.now().minusMonths(months);
+        List<Object[]> raw = regRepo.findMonthlyTrend(from);
+
+        final long[] cumulative = {0};
+        return raw.stream().map(row -> {
+            long count = ((Number) row[1]).longValue();
+            cumulative[0] += count;
+            return RegistrationTrendDTO.builder()
+                    .period(row[0].toString())
+                    .registrationCount(count)
+                    .cumulativeTotal(cumulative[0])
+                    .build();
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the top N most popular events ordered by registration count.
+     */
+    public List<Map<String, Object>> getPopularEvents(int limit) {
+        return eventAnalyticsRepo.findMostPopularEvents(PageRequest.of(0, limit))
+                .stream()
+                .map(row -> {
+                    Map<String, Object> m = new LinkedHashMap<>();
+                    m.put("eventId",       ((Number) row[0]).longValue());
+                    m.put("eventTitle",    row[1].toString());
+                    m.put("registrations", ((Number) row[2]).longValue());
+                    m.put("capacity",
+                            row[3] != null ? ((Number) row[3]).intValue() : "Unlimited");
+                    m.put("utilization",
+                            row[4] != null
+                                    ? String.format("%.1f%%", ((Number) row[4]).doubleValue() * 100)
+                                    : "N/A");
+                    return m;
+                })
+                .collect(Collectors.toList());
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // 5. FEEDBACK MANAGEMENT
+    // ══════════════════════════════════════════════════════════════════════
+
+    /**
+     * Returns all feedback entries (paginated).
+     */
+    public PagedResponse<AdminFeedbackResponse> getAllFeedback(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("submittedAt").descending());
+        return PagedResponse.from(feedbackRepository.findAll(pageable).map(this::toAdminFeedbackResponse));
+    }
+
+    /**
+     * Deletes a feedback entry by ID.
+     */
+    @Transactional
+    public void deleteFeedback(Long id) {
+        if (!feedbackRepository.existsById(id)) {
+            throw new EntityNotFoundException("Feedback not found with id: " + id);
+        }
+        feedbackRepository.deleteById(id);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════
+    // Private helpers
+    // ══════════════════════════════════════════════════════════════════════
+
+    private AdminUserResponse toAdminUserResponse(User user) {
+        return AdminUserResponse.builder()
+                .id(user.getId())
+                .firstName(user.getFirstName())
+                .lastName(user.getLastName())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .role(user.getRole() != null ? user.getRole().name() : null)
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+
+    private EventResponse toEventResponse(com.sandeep.eventrabackend.model.Event event) {
+        return EventResponse.builder()
+                .id(event.getId())
+                .title(event.getTitle())
+                .description(event.getDescription())
+                .location(event.getLocation())
+                .eventDate(event.getEventDate())
+                .capacity(event.getCapacity())
+                .registeredCount(event.getRegisteredCount())
+                .isPublic(event.isPublic())
+                .imageUrl(event.getImageUrl())
+                .build();
+    }
+
+    private HackathonResponse toHackathonResponse(Hackathon h) {
+        return HackathonResponse.builder()
+                .id(h.getId())
+                .title(h.getTitle())
+                .description(h.getDescription())
+                .organizer(h.getOrganizer())
+                .startDate(h.getStartDate())
+                .endDate(h.getEndDate())
+                .location(h.getLocation())
+                .mode(h.getMode())
+                .prizePool(h.getPrizePool())
+                .registrationDeadline(h.getRegistrationDeadline())
+                .imageUrl(h.getImageUrl())
+                .build();
+    }
+
+    private AdminFeedbackResponse toAdminFeedbackResponse(Feedback f) {
+        return AdminFeedbackResponse.builder()
+                .id(f.getId())
+                .eventId(f.getEvent() != null ? f.getEvent().getId() : null)
+                .eventTitle(f.getEvent() != null ? f.getEvent().getTitle() : null)
+                .userId(f.getUser() != null ? f.getUser().getId() : null)
+                .username(f.getUser() != null ? f.getUser().getUsername() : null)
+                .rating(f.getRating())
+                .comment(f.getComment())
+                .submittedAt(f.getSubmittedAt())
+                .build();
+    }
+
+    private Role parseRole(String role) {
+        try {
+            return Role.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid role: " + role +
+                    ". Must be one of: CLIENT, ORGANIZER, ADMIN, SUPER_ADMIN");
+        }
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/EventService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EventService.java
@@ -65,8 +65,6 @@ public class EventService {
         this.userRepository = userRepository;
     }
 
-    // ── Issue #2101 — Event Availability Check ───────────────────────────────
-
     /**
      * Returns availability data for the given event.
      * The endpoint is public (no JWT required) so anyone can check spots.
@@ -268,7 +266,6 @@ public class EventService {
                 "Registration could not be completed due to high demand. Please try again.");
     }
 
-    // ── Private Helpers ──────────────────────────────────────────────────────
 
     private RegistrationResponse executeRegistration(
             Long eventId,


### PR DESCRIPTION
Adds a secured admin controller and service for managing users, events, hackathons, feedback, and dashboard analytics. Also introduces admin-facing DTOs, paginated response wrappers, repository support for role and growth queries, and restricts `/api/admin/**` routes to ADMIN and SUPER_ADMIN authorities.