### PR TITLE
feat: implement forgot-password and reset-password endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,44 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.4.4</version>
-        <relativePath/> </parent>
+        <relativePath />
+    </parent>
     <groupId>com.sandeep</groupId>
     <artifactId>Eventra-Backend</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Eventra-Backend</name>
     <description>Eventra-Backend - Event Management Platform API</description>
-    <url/>
+    <url />
     <licenses>
-        <license/>
+        <license />
     </licenses>
     <developers>
-        <developer/>
+        <developer />
     </developers>
     <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
+        <connection />
+        <developerConnection />
+        <tag />
+        <url />
     </scm>
     <properties>
         <java.version>17</java.version>
     </properties>
     <dependencies>
 
-    <dependency>
-    <groupId>com.google.api-client</groupId>
-    <artifactId>google-api-client</artifactId>
-    <version>2.2.0</version>
-</dependency>
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>2.2.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
 
         <dependency>
@@ -117,7 +124,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-        
+
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
+++ b/src/main/java/com/sandeep/eventrabackend/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.sandeep.eventrabackend.controller;
 import com.sandeep.eventrabackend.dto.request.LoginRequest;
 import com.sandeep.eventrabackend.dto.request.SignupRequest;
 import com.sandeep.eventrabackend.dto.request.GoogleAuthRequest;
+import com.sandeep.eventrabackend.dto.request.ForgotPasswordRequest;
+import com.sandeep.eventrabackend.dto.request.ResetPasswordRequest;
 import com.sandeep.eventrabackend.dto.response.AuthResponse;
 import com.sandeep.eventrabackend.dto.response.ErrorResponse;
 import com.sandeep.eventrabackend.service.AuthService;
@@ -164,5 +166,52 @@ public ResponseEntity<AuthResponse> googleLogin(
             return ResponseEntity.ok("Logged out successfully");
         }
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token format");
+    }
+
+    // ─── FORGOT PASSWORD ────────────────────────────────────────────────────────
+
+    @PostMapping("/forgot-password")
+    @SecurityRequirements
+    @Operation(
+            summary = "Request a password reset link",
+            description = """
+                    Sends a password reset link to the provided email if an account exists.
+                    
+                    For security, this endpoint always returns a success response,
+                    regardless of whether the email is registered.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Request processed"),
+            @ApiResponse(responseCode = "400", description = "Validation error",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "429", description = "Rate limit exceeded",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+        authService.forgotPassword(request);
+        return ResponseEntity.ok("If an account with that email exists, a reset link has been sent.");
+    }
+
+    // ─── RESET PASSWORD ─────────────────────────────────────────────────────────
+
+    @PostMapping("/reset-password")
+    @SecurityRequirements
+    @Operation(
+            summary = "Reset password using a valid token",
+            description = """
+                    Resets the user's password using the token sent via email.
+                    
+                    Token expires 15 minutes after being issued.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Password reset successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid/expired token or passwords don't match",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        authService.resetPassword(request);
+        return ResponseEntity.ok("Password has been reset successfully.");
     }
 }

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/ForgotPasswordRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/ForgotPasswordRequest.java
@@ -1,0 +1,19 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForgotPasswordRequest {
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Email must be valid")
+    private String email;
+}

--- a/src/main/java/com/sandeep/eventrabackend/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/sandeep/eventrabackend/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,25 @@
+package com.sandeep.eventrabackend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResetPasswordRequest {
+
+    @NotBlank(message = "Token is required")
+    private String token;
+
+    @NotBlank(message = "New password is required")
+    @Size(min = 8, message = "Password must be at least 8 characters")
+    private String newPassword;
+
+    @NotBlank(message = "Confirm password is required")
+    private String confirmPassword;
+}

--- a/src/main/java/com/sandeep/eventrabackend/exception/InvalidTokenException.java
+++ b/src/main/java/com/sandeep/eventrabackend/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.sandeep.eventrabackend.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/model/PasswordResetToken.java
+++ b/src/main/java/com/sandeep/eventrabackend/model/PasswordResetToken.java
@@ -1,0 +1,40 @@
+package com.sandeep.eventrabackend.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "password_reset_tokens")
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(name = "user_email", nullable = false)
+    private String userEmail;
+
+    @Column(name = "expiry_date", nullable = false)
+    private LocalDateTime expiryDate;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiryDate);
+    }
+}

--- a/src/main/java/com/sandeep/eventrabackend/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/sandeep/eventrabackend/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,15 @@
+package com.sandeep.eventrabackend.repository;
+
+import com.sandeep.eventrabackend.model.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    Optional<PasswordResetToken> findByToken(String token);
+
+    void deleteByUserEmail(String userEmail);
+}

--- a/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/AuthService.java
@@ -1,5 +1,11 @@
 package com.sandeep.eventrabackend.service;
 
+import com.sandeep.eventrabackend.dto.request.ForgotPasswordRequest;
+import com.sandeep.eventrabackend.dto.request.ResetPasswordRequest;
+import com.sandeep.eventrabackend.exception.InvalidTokenException;
+import com.sandeep.eventrabackend.model.PasswordResetToken;
+import com.sandeep.eventrabackend.repository.PasswordResetTokenRepository;
+import java.time.LocalDateTime;
 import com.sandeep.eventrabackend.dto.request.LoginRequest;
 import com.sandeep.eventrabackend.dto.request.SignupRequest;
 import com.sandeep.eventrabackend.dto.response.AuthResponse;
@@ -29,13 +35,17 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleAuthService googleAuthService;
     private final TokenBlacklistService tokenBlacklistService;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final EmailService emailService;
 
     public AuthService(UserRepository userRepository,
                    PasswordEncoder passwordEncoder,
                    AuthenticationManager authenticationManager,
                    JwtTokenProvider jwtTokenProvider,
                    GoogleAuthService googleAuthService,
-                   TokenBlacklistService tokenBlacklistService) {
+                   TokenBlacklistService tokenBlacklistService,
+                   PasswordResetTokenRepository passwordResetTokenRepository,
+                   EmailService emailService) {
 
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
@@ -43,6 +53,8 @@ public class AuthService {
     this.jwtTokenProvider = jwtTokenProvider;
     this.googleAuthService = googleAuthService;
     this.tokenBlacklistService = tokenBlacklistService;
+    this.passwordResetTokenRepository = passwordResetTokenRepository;
+    this.emailService = emailService;
 }
 
     @Transactional
@@ -167,6 +179,53 @@ if (lastName == null || lastName.isBlank()) {
         tokenBlacklistService.addToBlacklist(token, expiration);
     }
 
+    @Transactional
+    public void forgotPassword(ForgotPasswordRequest request) {
+        User user = userRepository.findByEmail(request.getEmail().toLowerCase()).orElse(null);
+
+        // Don't reveal whether the email exists — always behave the same way
+        if (user == null) {
+            return;
+        }
+
+        // Remove any existing token for this user before creating a new one
+        passwordResetTokenRepository.deleteByUserEmail(user.getEmail());
+
+        String token = UUID.randomUUID().toString();
+        PasswordResetToken resetToken = PasswordResetToken.builder()
+                .token(token)
+                .userEmail(user.getEmail())
+                .expiryDate(LocalDateTime.now().plusMinutes(15))
+                .build();
+
+        passwordResetTokenRepository.save(resetToken);
+        emailService.sendPasswordResetEmail(user.getEmail(), token);
+    }
+
+    @Transactional
+    public void resetPassword(ResetPasswordRequest request) {
+        if (!request.getNewPassword().equals(request.getConfirmPassword())) {
+            throw new PasswordMismatchException("New password and confirm password do not match");
+        }
+
+        PasswordResetToken resetToken = passwordResetTokenRepository
+                .findByToken(request.getToken())
+                .orElseThrow(() -> new InvalidTokenException("Invalid or expired reset token"));
+
+        if (resetToken.isExpired()) {
+            passwordResetTokenRepository.deleteByUserEmail(resetToken.getUserEmail());
+            throw new InvalidTokenException("Reset token has expired");
+        }
+
+        User user = userRepository.findByEmail(resetToken.getUserEmail())
+                .orElseThrow(() -> new InvalidTokenException("User not found"));
+
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
+
+        passwordResetTokenRepository.deleteByUserEmail(user.getEmail());
+    }
+
     // ─── helpers ────────────────────────────────────────────────────────────────
 
 
@@ -192,4 +251,3 @@ if (lastName == null || lastName.isBlank()) {
                 .build();
     }
 }
-

--- a/src/main/java/com/sandeep/eventrabackend/service/EmailService.java
+++ b/src/main/java/com/sandeep/eventrabackend/service/EmailService.java
@@ -1,0 +1,36 @@
+package com.sandeep.eventrabackend.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${app.frontend-url:https://eventra.sandeepvashishtha.in}")
+    private String frontendUrl;
+
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendPasswordResetEmail(String toEmail, String token) {
+        String resetLink = frontendUrl + "/reset-password?token=" + token;
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject("Eventra - Password Reset Request");
+        message.setText(
+                "You requested a password reset.\n\n" +
+                "Click the link below to reset your password:\n" +
+                resetLink + "\n\n" +
+                "This link will expire in 15 minutes.\n\n" +
+                "If you did not request this, please ignore this email."
+        );
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,18 @@ spring:
 
     database-platform: org.hibernate.dialect.H2Dialect
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## Description
Implements the missing `forgot-password` and `reset-password` endpoints. The rate-limiting config already referenced these routes, but there was no actual controller/service handling them — requests were failing with a 500 error since no email/password-reset logic existed in the backend (see #68).

Closes #68

## Changes
- Added `PasswordResetToken` entity to store reset tokens with expiry
- Added `PasswordResetTokenRepository` for token persistence
- Added `EmailService` using `JavaMailSender` to send reset emails
- Added `ForgotPasswordRequest` / `ResetPasswordRequest` DTOs with validation
- Added `AuthService.forgotPassword()` and `AuthService.resetPassword()`
- Added `POST /api/auth/forgot-password` and `POST /api/auth/reset-password` endpoints in `AuthController`
- Added `InvalidTokenException` for expired/invalid token handling
- Added `spring-boot-starter-mail` dependency and SMTP config in `application.yml`

## How it works
1. `POST /forgot-password` — looks up user by email, generates a secure token (15 min expiry), stores it, and emails a reset link. Always returns a generic success response regardless of whether the email exists (prevents email enumeration).
2. `POST /reset-password` — validates the token, checks expiry, updates the user's password (hashed via existing `PasswordEncoder`), and invalidates the token after use.

## Testing
- Verified `mvn clean compile` builds successfully with no errors
- Verified application starts successfully via `mvn spring-boot:run`
- Tested `POST /api/auth/forgot-password` locally with curl — returns 200 with a generic success message instead of the original 500 error
- Have not yet tested actual email delivery (requires real SMTP credentials) or the full `reset-password` flow with a live token — happy to verify further if useful